### PR TITLE
Replace option to disable the cache

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -140,9 +140,9 @@ $query = (new ExchangeRateQueryBuilder('JPY/GBP'))
     ->addOption('cache_ttl', 60)
     ->build();
     
-// Force refreshing the rate from the service for this query
+// Disable caching for this query
 $query = (new ExchangeRateQueryBuilder('JPY/GBP'))
-    ->addOption('cache_refresh', true)
+    ->addOption('cache', false)
     ->build();
 ```    
 

--- a/src/Exchanger.php
+++ b/src/Exchanger.php
@@ -50,13 +50,13 @@ class Exchanger implements ExchangeRateProviderContract
             throw new UnsupportedExchangeQueryException($exchangeQuery, $this->service);
         }
 
-        if (null === $this->cacheItemPool) {
+        if (null === $this->cacheItemPool || false === $exchangeQuery->getOption('cache')) {
             return $this->service->getExchangeRate($exchangeQuery);
         }
 
         $item = $this->cacheItemPool->getItem(sha1(serialize($exchangeQuery)));
 
-        if (!$exchangeQuery->getOption('cache_refresh') && $item->isHit()) {
+        if ($item->isHit()) {
             return $item->get();
         }
 

--- a/tests/Tests/ExchangerTest.php
+++ b/tests/Tests/ExchangerTest.php
@@ -227,9 +227,9 @@ class ExchangerTest extends \PHPUnit_Framework_TestCase
     /**
      * @test
      */
-    public function it_does_not_use_cache_if_refresh()
+    public function it_does_not_use_cache_if_cache_false()
     {
-        $exchangeRateQuery = new ExchangeRateQuery(CurrencyPair::createFromString('EUR/USD'), ['cache_refresh' => true]);
+        $exchangeRateQuery = new ExchangeRateQuery(CurrencyPair::createFromString('EUR/USD'), ['cache' => false]);
 
         $service = $this->getMock('Exchanger\Contract\ExchangeRateService');
 
@@ -251,12 +251,12 @@ class ExchangerTest extends \PHPUnit_Framework_TestCase
         $pool = $this->getMock('Psr\Cache\CacheItemPoolInterface');
 
         $pool
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('getItem')
             ->will($this->returnValue($item));
 
         $pool
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('save')
             ->with($item);
 


### PR DESCRIPTION
This replaces the `cache_refresh` option by a  `cache` option instead to disable caching for a specific query.