### PR TITLE
Add descriptive error message to ChainException

### DIFF
--- a/src/Exception/ChainException.php
+++ b/src/Exception/ChainException.php
@@ -27,6 +27,22 @@ class ChainException extends Exception
      */
     public function __construct(array $exceptions)
     {
+        $messages = array_map(function(\Exception $exception) {
+            return sprintf(
+                '%s: %s',
+                get_class($exception),
+                $exception->getMessage()
+            );
+        }, $exceptions);
+
+        parent::__construct(
+            sprintf(
+                "The chain resulted in %d exception(s):\r\n%s",
+                count($exceptions),
+                implode("\r\n", $messages)
+            )
+        );
+
         $this->exceptions = $exceptions;
     }
 

--- a/tests/Tests/Exception/ChainExceptionTest.php
+++ b/tests/Tests/Exception/ChainExceptionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Exchanger\Tests\Exception;
+
+use Exchanger\Exception\ChainException;
+use Exchanger\Exception\InternalException;
+
+/**
+ * @covers \Exchanger\Exception\ChainException
+ */
+class ChainExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ChainException
+     */
+    private $chainException;
+
+    /**
+     * @var \Exception
+     */
+    private $exception1;
+
+    /**
+     * @var \Exception
+     */
+    private $exception2;
+
+    public function setUp()
+    {
+        $this->exception1 = new InternalException('Something bad happened.');
+        $this->exception2 = new \Exception('General exception.');
+
+        $this->chainException = new ChainException(array(
+            $this->exception1,
+            $this->exception2,
+        ));
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_have_a_descriptive_error_message()
+    {
+        $this->assertSame("The chain resulted in 2 exception(s):\r\nExchanger\\Exception\\InternalException: Something bad happened.\r\nException: General exception.", $this->chainException->getMessage());
+        $this->assertCount(2, $this->chainException->getExceptions());
+    }
+}


### PR DESCRIPTION
We've seen this exceptions a couple of times in Sentry popping up. Since the exception is actually a holder of multiple exceptions, it was not clear what actually caused the issue.

With this change, it will immediately be clear what is wrong. It will help developers to fix the actual problem faster.