### PR TITLE
Added new option 'cache_key_prefix' to Exchanger

### DIFF
--- a/doc/readme.md
+++ b/doc/readme.md
@@ -125,10 +125,10 @@ The following example uses the Apcu cache from [php-cache.com](http://php-cache.
 ```php
 use Cache\Adapter\Apcu\ApcuCachePool;
 
-$exchanger = new Exchanger($service, new ApcuCachePool(), ['cache_ttl' => 3600]);
+$exchanger = new Exchanger($service, new ApcuCachePool(), ['cache_ttl' => 3600, 'cache_key_prefix' => 'myapp-']);
 ```
 
-All rates will now be cached in Apcu during 3600 seconds.
+All rates will now be cached in Apcu during 3600 seconds, and cache keys will be prefixed with 'myapp-'
 
 ##### Query Cache Options
 
@@ -143,6 +143,11 @@ $query = (new ExchangeRateQueryBuilder('JPY/GBP'))
 // Disable caching for this query
 $query = (new ExchangeRateQueryBuilder('JPY/GBP'))
     ->addOption('cache', false)
+    ->build();
+
+// Override cache key prefix for this query
+$query = (new ExchangeRateQueryBuilder('JPY/GBP'))
+    ->addOption('cache_key_prefix', 'currencies:special:')
     ->build();
 ```    
 

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -134,20 +134,41 @@ All rates will now be cached in Apcu during 3600 seconds, and cache keys will be
 
 For more control, you can configure the cache per query.
 
+###### cache_ttl
+
+Set cache TTL in seconds. Default: `null` - cache entries permanently
+
 ```php
 // Override the global cache_ttl only for this query
 $query = (new ExchangeRateQueryBuilder('JPY/GBP'))
     ->addOption('cache_ttl', 60)
     ->build();
-    
+```
+
+###### cache
+
+Disable/Enable caching. Default: `true`
+
+```php
 // Disable caching for this query
 $query = (new ExchangeRateQueryBuilder('JPY/GBP'))
     ->addOption('cache', false)
     ->build();
+```
 
+###### cache_key_prefix
+
+Set the cache key prefix. Default: empty string
+
+There is a limitation of 64 characters for the key length in PSR-6,
+ because of this, key prefix must not exceed 24 characters, as sha1() hash takes 40 symbols.
+
+PSR-6 do not allows characters `{}()/\@:` in key, these characters are replaced with `-`
+
+```php
 // Override cache key prefix for this query
 $query = (new ExchangeRateQueryBuilder('JPY/GBP'))
-    ->addOption('cache_key_prefix', 'currencies:special:')
+    ->addOption('cache_key_prefix', 'currencies-special-')
     ->build();
 ```    
 

--- a/src/Exception/CacheException.php
+++ b/src/Exception/CacheException.php
@@ -1,0 +1,14 @@
+<?php
+
+
+namespace Exchanger\Exception;
+
+/**
+ * Exception thrown by problems with cache.
+ *
+ * @author Hennadiy Verkh
+ */
+class CacheException extends Exception
+{
+
+}

--- a/src/Exception/CacheException.php
+++ b/src/Exception/CacheException.php
@@ -4,7 +4,7 @@
 namespace Exchanger\Exception;
 
 /**
- * Exception thrown by problems with cache.
+ * Exception thrown in case of problems with cache.
  *
  * @author Hennadiy Verkh
  */

--- a/tests/Tests/ExchangerTest.php
+++ b/tests/Tests/ExchangerTest.php
@@ -320,6 +320,26 @@ class ExchangerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     * @expectedException \Exchanger\Exception\CacheException
+     */
+    public function it_throws_an_exception_if_cache_key_is_too_long()
+    {
+        $exchangeRateQuery = new ExchangeRateQuery(CurrencyPair::createFromString('EUR/USD'));
+
+        $service = $this->getMock('Exchanger\Contract\ExchangeRateService');
+
+        $pool = $this->getMock('Psr\Cache\CacheItemPoolInterface');
+        $service
+            ->expects($this->any())
+            ->method('supportQuery')
+            ->will($this->returnValue(true));
+
+        $exchanger = new Exchanger($service, $pool, ['cache_key_prefix' => 'prefix_longer_then_24_symbols']);
+        $exchanger->getExchangeRate($exchangeRateQuery);
+    }
+
+    /**
+     * @test
      * @expectedException \Exchanger\Exception\UnsupportedExchangeQueryException
      */
     public function it_throws_an_exception_if_service_cant_support_pair()

--- a/tests/Tests/ExchangerTest.php
+++ b/tests/Tests/ExchangerTest.php
@@ -320,6 +320,33 @@ class ExchangerTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @test
+     */
+    public function it_supports_overrding_cache_prefix_per_query()
+    {
+        $expectedKeyPrefix = 'expected-prefix';
+        $exchangeRateQuery = new ExchangeRateQuery(CurrencyPair::createFromString('EUR/USD'), ['cache_key_prefix' => $expectedKeyPrefix]);
+
+        $service = $this->getMock('Exchanger\Contract\ExchangeRateService');
+        $item = $this->getMock('Psr\Cache\CacheItemInterface');
+        $pool = $this->getMock('Psr\Cache\CacheItemPoolInterface');
+
+        $service
+            ->expects($this->once())
+            ->method('supportQuery')
+            ->will($this->returnValue(true));
+
+        $pool
+            ->expects($this->once())
+            ->method('getItem')
+            ->with($this->stringStartsWith($expectedKeyPrefix))
+            ->will($this->returnValue($item));
+
+        $exchanger = new Exchanger($service, $pool);
+        $exchanger->getExchangeRate($exchangeRateQuery);
+    }
+
+    /**
+     * @test
      * @expectedException \Exchanger\Exception\CacheException
      */
     public function it_throws_an_exception_if_cache_key_is_too_long()


### PR DESCRIPTION
I propose the option to set prefix for cache keys.
In my case, sometimes, I need to delete cached currencies from the redis cache. I cannot find the keys from exchanger, because they are just random sha1 strings, and there are thousands of other keys - the only solution is to flush the whole cache, deleting other entries.
Because of this, I have added an option for exchanger to set the prefix for the key. Now, you can easily find cached entries from exchanger ( e.g. using 'my-prefix-*' on redis), and debug, or modify them. 
One more point, PSR-6 standard does not allow symbols `{}()/\@:` in key name, they are replaced with `-`, also, if the key is longer that 64 symbols it violates PSR-6 and an exception is throwed.