### PR TITLE
Added historical service for National Bank Of Romania

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Here is the list of the currently implemented services.
 | [Open Exchange Rates](https://openexchangerates.org) | USD (free), * (paid) | * | Yes |
 | [Xignite](https://www.xignite.com) | * | * | Yes |
 | [WebserviceX](http://www.webservicex.net/ws/default.aspx) | * | * | No |
-| [National Bank of Romania](http://www.bnr.ro) | RON | * | No |
+| [National Bank of Romania](http://www.bnr.ro) | RON | * | Yes |
 | [Central Bank of the Republic of Turkey](http://www.tcmb.gov.tr) | * | TRY | No |
 | [Central Bank of the Czech Republic](http://www.cnb.cz) | * | CZK | No |
 | [Russian Central Bank](http://http://www.cbr.ru) | * | RUB | Yes |

--- a/src/Service/NationalBankOfRomania.php
+++ b/src/Service/NationalBankOfRomania.php
@@ -14,6 +14,7 @@ namespace Exchanger\Service;
 use Exchanger\Contract\ExchangeRateQuery;
 use Exchanger\Contract\HistoricalExchangeRateQuery;
 use Exchanger\Exception\UnsupportedCurrencyPairException;
+use Exchanger\Exception\UnsupportedDateException;
 use Exchanger\ExchangeRate;
 use Exchanger\StringUtil;
 
@@ -22,15 +23,17 @@ use Exchanger\StringUtil;
  *
  * @author Mihai Zaharie <mihai@zaharie.ro>
  * @author Florian Voutzinos <florian@voutzinos.com>
+ * @author Balazs Csaba <balazscsaba2006@gmail.com>
  */
-class NationalBankOfRomania extends Service
+class NationalBankOfRomania extends HistoricalService
 {
     const URL = 'http://www.bnr.ro/nbrfxrates.xml';
+    const HISTORICAL_URL_TEMPLATE = 'http://www.bnr.ro/files/xml/years/nbrfxrates{year}.xml';
 
     /**
      * {@inheritdoc}
      */
-    public function getExchangeRate(ExchangeRateQuery $exchangeQuery)
+    public function getLatestExchangeRate(ExchangeRateQuery $exchangeQuery)
     {
         $content = $this->request(self::URL);
 
@@ -50,6 +53,45 @@ class NationalBankOfRomania extends Service
         $rateValue = (!empty($element['multiplier'])) ? $rate / (int) $element['multiplier'] : $rate;
 
         return new ExchangeRate((string) $rateValue, $date);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getHistoricalExchangeRate(HistoricalExchangeRateQuery $exchangeQuery)
+    {
+        $year = $exchangeQuery->getDate()->format('Y');
+        if ($year < 2005) {
+            throw new UnsupportedDateException($exchangeQuery->getDate(), $this);
+        }
+
+        $url = str_replace('{year}', $year, self::HISTORICAL_URL_TEMPLATE);
+        $content = $this->request($url);
+
+        // remove BOM from beginning of content
+        $content = substr($content, strpos($content, '<'));
+
+        $element = StringUtil::xmlToElement($content);
+        $element->registerXPathNamespace('xmlns', 'http://www.bnr.ro/xsd');
+
+        $formattedDate = $exchangeQuery->getDate()->format('Y-m-d');
+        $baseCurrency = $exchangeQuery->getCurrencyPair()->getBaseCurrency();
+
+        $elements = $element->xpath('//xmlns:Cube[@date="'.$formattedDate.'"]/xmlns:Rate[@currency="'.$baseCurrency.'"]');
+
+        if (empty($elements)) {
+            if (empty($element->xpath('//xmlns:Cube[@date="'.$formattedDate.'"]'))) {
+                throw new UnsupportedDateException($exchangeQuery->getDate(), $this);
+            }
+
+            throw new UnsupportedCurrencyPairException($exchangeQuery->getCurrencyPair(), $this);
+        }
+
+        $element = $elements[0];
+        $rate = (string) $element;
+        $rateValue = (!empty($element['multiplier'])) ? $rate / (int) $element['multiplier'] : $rate;
+
+        return new ExchangeRate((string) $rateValue, $exchangeQuery->getDate());
     }
 
     /**

--- a/tests/Fixtures/Service/NationalBankOfRomania/nbrfxrates2018.xml
+++ b/tests/Fixtures/Service/NationalBankOfRomania/nbrfxrates2018.xml
@@ -1,0 +1,930 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DataSet xmlns="http://www.bnr.ro/xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.bnr.ro/xsd nbrfxrates.xsd">
+    <Header>
+        <Publisher>National Bank of Romania</Publisher>
+        <PublishingDate>2018-02-09</PublishingDate>
+        <MessageType>DR</MessageType>
+    </Header>
+    <Body>
+        <Subject>Reference rates</Subject>
+        <OrigCurrency>RON</OrigCurrency>
+        <Cube date="2018-01-03">
+            <Rate currency="AED">1.0510</Rate>
+            <Rate currency="AUD">3.0245</Rate>
+            <Rate currency="BGN">2.3730</Rate>
+            <Rate currency="BRL">1.1841</Rate>
+            <Rate currency="CAD">3.0842</Rate>
+            <Rate currency="CHF">3.9623</Rate>
+            <Rate currency="CNY">0.5940</Rate>
+            <Rate currency="CZK">0.1815</Rate>
+            <Rate currency="DKK">0.6235</Rate>
+            <Rate currency="EGP">0.2177</Rate>
+            <Rate currency="EUR">4.6412</Rate>
+            <Rate currency="GBP">5.2425</Rate>
+            <Rate currency="HRK">0.6236</Rate>
+            <Rate currency="HUF" multiplier="100">1.5010</Rate>
+            <Rate currency="INR">0.0608</Rate>
+            <Rate currency="JPY" multiplier="100">3.4393</Rate>
+            <Rate currency="KRW" multiplier="100">0.3625</Rate>
+            <Rate currency="MDL">0.2251</Rate>
+            <Rate currency="MXN">0.1987</Rate>
+            <Rate currency="NOK">0.4758</Rate>
+            <Rate currency="NZD">2.7438</Rate>
+            <Rate currency="PLN">1.1132</Rate>
+            <Rate currency="RSD">0.0390</Rate>
+            <Rate currency="RUB">0.0673</Rate>
+            <Rate currency="SEK">0.4721</Rate>
+            <Rate currency="THB">0.1196</Rate>
+            <Rate currency="TRY">1.0260</Rate>
+            <Rate currency="UAH">0.1385</Rate>
+            <Rate currency="USD">3.8603</Rate>
+            <Rate currency="XAU">163.1042</Rate>
+            <Rate currency="XDR">5.5074</Rate>
+            <Rate currency="ZAR">0.3124</Rate>
+        </Cube>
+        <Cube date="2018-01-04">
+            <Rate currency="AED">1.0461</Rate>
+            <Rate currency="AUD">3.0164</Rate>
+            <Rate currency="BGN">2.3675</Rate>
+            <Rate currency="BRL">1.1870</Rate>
+            <Rate currency="CAD">3.0700</Rate>
+            <Rate currency="CHF">3.9389</Rate>
+            <Rate currency="CNY">0.5915</Rate>
+            <Rate currency="CZK">0.1817</Rate>
+            <Rate currency="DKK">0.6219</Rate>
+            <Rate currency="EGP">0.2170</Rate>
+            <Rate currency="EUR">4.6304</Rate>
+            <Rate currency="GBP">5.2074</Rate>
+            <Rate currency="HRK">0.6237</Rate>
+            <Rate currency="HUF" multiplier="100">1.5012</Rate>
+            <Rate currency="INR">0.0606</Rate>
+            <Rate currency="JPY" multiplier="100">3.4132</Rate>
+            <Rate currency="KRW" multiplier="100">0.3618</Rate>
+            <Rate currency="MDL">0.2257</Rate>
+            <Rate currency="MXN">0.1995</Rate>
+            <Rate currency="NOK">0.4747</Rate>
+            <Rate currency="NZD">2.7375</Rate>
+            <Rate currency="PLN">1.1145</Rate>
+            <Rate currency="RSD">0.0389</Rate>
+            <Rate currency="RUB">0.0672</Rate>
+            <Rate currency="SEK">0.4712</Rate>
+            <Rate currency="THB">0.1192</Rate>
+            <Rate currency="TRY">1.0213</Rate>
+            <Rate currency="UAH">0.1371</Rate>
+            <Rate currency="USD">3.8425</Rate>
+            <Rate currency="XAU">162.2684</Rate>
+            <Rate currency="XDR">5.4845</Rate>
+            <Rate currency="ZAR">0.3126</Rate>
+        </Cube>
+        <Cube date="2018-01-05">
+            <Rate currency="AED">1.0477</Rate>
+            <Rate currency="AUD">3.0193</Rate>
+            <Rate currency="BGN">2.3706</Rate>
+            <Rate currency="BRL">1.1897</Rate>
+            <Rate currency="CAD">3.0773</Rate>
+            <Rate currency="CHF">3.9394</Rate>
+            <Rate currency="CNY">0.5935</Rate>
+            <Rate currency="CZK">0.1818</Rate>
+            <Rate currency="DKK">0.6227</Rate>
+            <Rate currency="EGP">0.2173</Rate>
+            <Rate currency="EUR">4.6365</Rate>
+            <Rate currency="GBP">5.2090</Rate>
+            <Rate currency="HRK">0.6238</Rate>
+            <Rate currency="HUF" multiplier="100">1.5035</Rate>
+            <Rate currency="INR">0.0607</Rate>
+            <Rate currency="JPY" multiplier="100">3.3989</Rate>
+            <Rate currency="KRW" multiplier="100">0.3624</Rate>
+            <Rate currency="MDL">0.2250</Rate>
+            <Rate currency="MXN">0.1993</Rate>
+            <Rate currency="NOK">0.4758</Rate>
+            <Rate currency="NZD">2.7533</Rate>
+            <Rate currency="PLN">1.1162</Rate>
+            <Rate currency="RSD">0.0391</Rate>
+            <Rate currency="RUB">0.0675</Rate>
+            <Rate currency="SEK">0.4724</Rate>
+            <Rate currency="THB">0.1194</Rate>
+            <Rate currency="TRY">1.0282</Rate>
+            <Rate currency="UAH">0.1366</Rate>
+            <Rate currency="USD">3.8484</Rate>
+            <Rate currency="XAU">163.0121</Rate>
+            <Rate currency="XDR">5.4908</Rate>
+            <Rate currency="ZAR">0.3112</Rate>
+        </Cube>
+        <Cube date="2018-01-08">
+            <Rate currency="AED">1.0508</Rate>
+            <Rate currency="AUD">3.0266</Rate>
+            <Rate currency="BGN">2.3698</Rate>
+            <Rate currency="BRL">1.1951</Rate>
+            <Rate currency="CAD">3.1118</Rate>
+            <Rate currency="CHF">3.9504</Rate>
+            <Rate currency="CNY">0.5940</Rate>
+            <Rate currency="CZK">0.1815</Rate>
+            <Rate currency="DKK">0.6224</Rate>
+            <Rate currency="EGP">0.2180</Rate>
+            <Rate currency="EUR">4.6348</Rate>
+            <Rate currency="GBP">5.2288</Rate>
+            <Rate currency="HRK">0.6227</Rate>
+            <Rate currency="HUF" multiplier="100">1.5009</Rate>
+            <Rate currency="INR">0.0609</Rate>
+            <Rate currency="JPY" multiplier="100">3.4131</Rate>
+            <Rate currency="KRW" multiplier="100">0.3616</Rate>
+            <Rate currency="MDL">0.2249</Rate>
+            <Rate currency="MXN">0.2012</Rate>
+            <Rate currency="NOK">0.4792</Rate>
+            <Rate currency="NZD">2.7699</Rate>
+            <Rate currency="PLN">1.1129</Rate>
+            <Rate currency="RSD">0.0391</Rate>
+            <Rate currency="RUB">0.0677</Rate>
+            <Rate currency="SEK">0.4724</Rate>
+            <Rate currency="THB">0.1199</Rate>
+            <Rate currency="TRY">1.0304</Rate>
+            <Rate currency="UAH">0.1364</Rate>
+            <Rate currency="USD">3.8598</Rate>
+            <Rate currency="XAU">163.9172</Rate>
+            <Rate currency="XDR">5.5005</Rate>
+            <Rate currency="ZAR">0.3116</Rate>
+        </Cube>
+        <Cube date="2018-01-09">
+            <Rate currency="AED">1.0628</Rate>
+            <Rate currency="AUD">3.0525</Rate>
+            <Rate currency="BGN">2.3812</Rate>
+            <Rate currency="BRL">1.2044</Rate>
+            <Rate currency="CAD">3.1385</Rate>
+            <Rate currency="CHF">3.9718</Rate>
+            <Rate currency="CNY">0.5980</Rate>
+            <Rate currency="CZK">0.1823</Rate>
+            <Rate currency="DKK">0.6254</Rate>
+            <Rate currency="EGP">0.2207</Rate>
+            <Rate currency="EUR">4.6571</Rate>
+            <Rate currency="GBP">5.2832</Rate>
+            <Rate currency="HRK">0.6253</Rate>
+            <Rate currency="HUF" multiplier="100">1.5076</Rate>
+            <Rate currency="INR">0.0613</Rate>
+            <Rate currency="JPY" multiplier="100">3.4598</Rate>
+            <Rate currency="KRW" multiplier="100">0.3646</Rate>
+            <Rate currency="MDL">0.2264</Rate>
+            <Rate currency="MXN">0.2024</Rate>
+            <Rate currency="NOK">0.4816</Rate>
+            <Rate currency="NZD">2.8003</Rate>
+            <Rate currency="PLN">1.1150</Rate>
+            <Rate currency="RSD">0.0392</Rate>
+            <Rate currency="RUB">0.0684</Rate>
+            <Rate currency="SEK">0.4737</Rate>
+            <Rate currency="THB">0.1210</Rate>
+            <Rate currency="TRY">1.0377</Rate>
+            <Rate currency="UAH">0.1383</Rate>
+            <Rate currency="USD">3.9039</Rate>
+            <Rate currency="XAU">165.0600</Rate>
+            <Rate currency="XDR">5.5492</Rate>
+            <Rate currency="ZAR">0.3146</Rate>
+        </Cube>
+        <Cube date="2018-01-10">
+            <Rate currency="AED">1.0536</Rate>
+            <Rate currency="AUD">3.0422</Rate>
+            <Rate currency="BGN">2.3742</Rate>
+            <Rate currency="BRL">1.1914</Rate>
+            <Rate currency="CAD">3.1128</Rate>
+            <Rate currency="CHF">3.9618</Rate>
+            <Rate currency="CNY">0.5947</Rate>
+            <Rate currency="CZK">0.1815</Rate>
+            <Rate currency="DKK">0.6235</Rate>
+            <Rate currency="EGP">0.2186</Rate>
+            <Rate currency="EUR">4.6434</Rate>
+            <Rate currency="GBP">5.2409</Rate>
+            <Rate currency="HRK">0.6235</Rate>
+            <Rate currency="HUF" multiplier="100">1.4970</Rate>
+            <Rate currency="INR">0.0609</Rate>
+            <Rate currency="JPY" multiplier="100">3.4762</Rate>
+            <Rate currency="KRW" multiplier="100">0.3624</Rate>
+            <Rate currency="MDL">0.2279</Rate>
+            <Rate currency="MXN">0.2007</Rate>
+            <Rate currency="NOK">0.4795</Rate>
+            <Rate currency="NZD">2.7956</Rate>
+            <Rate currency="PLN">1.1101</Rate>
+            <Rate currency="RSD">0.0391</Rate>
+            <Rate currency="RUB">0.0678</Rate>
+            <Rate currency="SEK">0.4726</Rate>
+            <Rate currency="THB">0.1206</Rate>
+            <Rate currency="TRY">1.0191</Rate>
+            <Rate currency="UAH">0.1365</Rate>
+            <Rate currency="USD">3.8700</Rate>
+            <Rate currency="XAU">164.4557</Rate>
+            <Rate currency="XDR">5.5191</Rate>
+            <Rate currency="ZAR">0.3098</Rate>
+        </Cube>
+        <Cube date="2018-01-11">
+            <Rate currency="AED">1.0569</Rate>
+            <Rate currency="AUD">3.0565</Rate>
+            <Rate currency="BGN">2.3711</Rate>
+            <Rate currency="BRL">1.2025</Rate>
+            <Rate currency="CAD">3.0929</Rate>
+            <Rate currency="CHF">3.9655</Rate>
+            <Rate currency="CNY">0.5968</Rate>
+            <Rate currency="CZK">0.1816</Rate>
+            <Rate currency="DKK">0.6227</Rate>
+            <Rate currency="EGP">0.2187</Rate>
+            <Rate currency="EUR">4.6374</Rate>
+            <Rate currency="GBP">5.2367</Rate>
+            <Rate currency="HRK">0.6226</Rate>
+            <Rate currency="HUF" multiplier="100">1.4999</Rate>
+            <Rate currency="INR">0.0610</Rate>
+            <Rate currency="JPY" multiplier="100">3.4768</Rate>
+            <Rate currency="KRW" multiplier="100">0.3630</Rate>
+            <Rate currency="MDL">0.2263</Rate>
+            <Rate currency="MXN">0.2011</Rate>
+            <Rate currency="NOK">0.4815</Rate>
+            <Rate currency="NZD">2.7999</Rate>
+            <Rate currency="PLN">1.1100</Rate>
+            <Rate currency="RSD">0.0390</Rate>
+            <Rate currency="RUB">0.0681</Rate>
+            <Rate currency="SEK">0.4737</Rate>
+            <Rate currency="THB">0.1212</Rate>
+            <Rate currency="TRY">1.0206</Rate>
+            <Rate currency="UAH">0.1364</Rate>
+            <Rate currency="USD">3.8821</Rate>
+            <Rate currency="XAU">164.6666</Rate>
+            <Rate currency="XDR">5.5258</Rate>
+            <Rate currency="ZAR">0.3116</Rate>
+        </Cube>
+        <Cube date="2018-01-12">
+            <Rate currency="AED">1.0413</Rate>
+            <Rate currency="AUD">3.0135</Rate>
+            <Rate currency="BGN">2.3713</Rate>
+            <Rate currency="BRL">1.1892</Rate>
+            <Rate currency="CAD">3.0560</Rate>
+            <Rate currency="CHF">3.9408</Rate>
+            <Rate currency="CNY">0.5923</Rate>
+            <Rate currency="CZK">0.1818</Rate>
+            <Rate currency="DKK">0.6227</Rate>
+            <Rate currency="EGP">0.2160</Rate>
+            <Rate currency="EUR">4.6377</Rate>
+            <Rate currency="GBP">5.2103</Rate>
+            <Rate currency="HRK">0.6217</Rate>
+            <Rate currency="HUF" multiplier="100">1.5029</Rate>
+            <Rate currency="INR">0.0601</Rate>
+            <Rate currency="JPY" multiplier="100">3.4440</Rate>
+            <Rate currency="KRW" multiplier="100">0.3599</Rate>
+            <Rate currency="MDL">0.2278</Rate>
+            <Rate currency="MXN">0.1991</Rate>
+            <Rate currency="NOK">0.4798</Rate>
+            <Rate currency="NZD">2.7771</Rate>
+            <Rate currency="PLN">1.1120</Rate>
+            <Rate currency="RSD">0.0391</Rate>
+            <Rate currency="RUB">0.0676</Rate>
+            <Rate currency="SEK">0.4715</Rate>
+            <Rate currency="THB">0.1197</Rate>
+            <Rate currency="TRY">1.0174</Rate>
+            <Rate currency="UAH">0.1340</Rate>
+            <Rate currency="USD">3.8247</Rate>
+            <Rate currency="XAU">163.8140</Rate>
+            <Rate currency="XDR">5.4817</Rate>
+            <Rate currency="ZAR">0.3085</Rate>
+        </Cube>
+        <Cube date="2018-01-15">
+            <Rate currency="AED">1.0261</Rate>
+            <Rate currency="AUD">2.9976</Rate>
+            <Rate currency="BGN">2.3651</Rate>
+            <Rate currency="BRL">1.1753</Rate>
+            <Rate currency="CAD">3.0335</Rate>
+            <Rate currency="CHF">3.9178</Rate>
+            <Rate currency="CNY">0.5863</Rate>
+            <Rate currency="CZK">0.1812</Rate>
+            <Rate currency="DKK">0.6209</Rate>
+            <Rate currency="EGP">0.2123</Rate>
+            <Rate currency="EUR">4.6256</Rate>
+            <Rate currency="GBP">5.1993</Rate>
+            <Rate currency="HRK">0.6221</Rate>
+            <Rate currency="HUF" multiplier="100">1.4976</Rate>
+            <Rate currency="INR">0.0594</Rate>
+            <Rate currency="JPY" multiplier="100">3.4068</Rate>
+            <Rate currency="KRW" multiplier="100">0.3543</Rate>
+            <Rate currency="MDL">0.2239</Rate>
+            <Rate currency="MXN">0.2000</Rate>
+            <Rate currency="NOK">0.4786</Rate>
+            <Rate currency="NZD">2.7470</Rate>
+            <Rate currency="PLN">1.1097</Rate>
+            <Rate currency="RSD">0.0391</Rate>
+            <Rate currency="RUB">0.0668</Rate>
+            <Rate currency="SEK">0.4703</Rate>
+            <Rate currency="THB">0.1180</Rate>
+            <Rate currency="TRY">1.0009</Rate>
+            <Rate currency="UAH">0.1323</Rate>
+            <Rate currency="USD">3.7686</Rate>
+            <Rate currency="XAU">162.6750</Rate>
+            <Rate currency="XDR">5.4328</Rate>
+            <Rate currency="ZAR">0.3062</Rate>
+        </Cube>
+        <Cube date="2018-01-16">
+            <Rate currency="AED">1.0395</Rate>
+            <Rate currency="AUD">3.0333</Rate>
+            <Rate currency="BGN">2.3826</Rate>
+            <Rate currency="BRL">1.1869</Rate>
+            <Rate currency="CAD">3.0695</Rate>
+            <Rate currency="CHF">3.9533</Rate>
+            <Rate currency="CNY">0.5926</Rate>
+            <Rate currency="CZK">0.1826</Rate>
+            <Rate currency="DKK">0.6256</Rate>
+            <Rate currency="EGP">0.2151</Rate>
+            <Rate currency="EUR">4.6599</Rate>
+            <Rate currency="GBP">5.2494</Rate>
+            <Rate currency="HRK">0.6272</Rate>
+            <Rate currency="HUF" multiplier="100">1.5080</Rate>
+            <Rate currency="INR">0.0596</Rate>
+            <Rate currency="JPY" multiplier="100">3.4491</Rate>
+            <Rate currency="KRW" multiplier="100">0.3581</Rate>
+            <Rate currency="MDL">0.2233</Rate>
+            <Rate currency="MXN">0.2025</Rate>
+            <Rate currency="NOK">0.4838</Rate>
+            <Rate currency="NZD">2.7747</Rate>
+            <Rate currency="PLN">1.1147</Rate>
+            <Rate currency="RSD">0.0394</Rate>
+            <Rate currency="RUB">0.0676</Rate>
+            <Rate currency="SEK">0.4744</Rate>
+            <Rate currency="THB">0.1194</Rate>
+            <Rate currency="TRY">0.9993</Rate>
+            <Rate currency="UAH">0.1333</Rate>
+            <Rate currency="USD">3.8182</Rate>
+            <Rate currency="XAU">163.5981</Rate>
+            <Rate currency="XDR">5.4907</Rate>
+            <Rate currency="ZAR">0.3110</Rate>
+        </Cube>
+        <Cube date="2018-01-17">
+            <Rate currency="AED">1.0364</Rate>
+            <Rate currency="AUD">3.0379</Rate>
+            <Rate currency="BGN">2.3813</Rate>
+            <Rate currency="BRL">1.1806</Rate>
+            <Rate currency="CAD">3.0601</Rate>
+            <Rate currency="CHF">3.9531</Rate>
+            <Rate currency="CNY">0.5915</Rate>
+            <Rate currency="CZK">0.1830</Rate>
+            <Rate currency="DKK">0.6253</Rate>
+            <Rate currency="EGP">0.2150</Rate>
+            <Rate currency="EUR">4.6573</Rate>
+            <Rate currency="GBP">5.2524</Rate>
+            <Rate currency="HRK">0.6268</Rate>
+            <Rate currency="HUF" multiplier="100">1.5068</Rate>
+            <Rate currency="INR">0.0596</Rate>
+            <Rate currency="JPY" multiplier="100">3.4395</Rate>
+            <Rate currency="KRW" multiplier="100">0.3565</Rate>
+            <Rate currency="MDL">0.2245</Rate>
+            <Rate currency="MXN">0.2027</Rate>
+            <Rate currency="NOK">0.4834</Rate>
+            <Rate currency="NZD">2.7705</Rate>
+            <Rate currency="PLN">1.1150</Rate>
+            <Rate currency="RSD">0.0394</Rate>
+            <Rate currency="RUB">0.0672</Rate>
+            <Rate currency="SEK">0.4728</Rate>
+            <Rate currency="THB">0.1192</Rate>
+            <Rate currency="TRY">0.9972</Rate>
+            <Rate currency="UAH">0.1326</Rate>
+            <Rate currency="USD">3.8067</Rate>
+            <Rate currency="XAU">163.7883</Rate>
+            <Rate currency="XDR">5.4810</Rate>
+            <Rate currency="ZAR">0.3089</Rate>
+        </Cube>
+        <Cube date="2018-01-18">
+            <Rate currency="AED">1.0361</Rate>
+            <Rate currency="AUD">3.0394</Rate>
+            <Rate currency="BGN">2.3783</Rate>
+            <Rate currency="BRL">1.1803</Rate>
+            <Rate currency="CAD">3.0605</Rate>
+            <Rate currency="CHF">3.9608</Rate>
+            <Rate currency="CNY">0.5924</Rate>
+            <Rate currency="CZK">0.1832</Rate>
+            <Rate currency="DKK">0.6246</Rate>
+            <Rate currency="EGP">0.2149</Rate>
+            <Rate currency="EUR">4.6514</Rate>
+            <Rate currency="GBP">5.2713</Rate>
+            <Rate currency="HRK">0.6256</Rate>
+            <Rate currency="HUF" multiplier="100">1.5078</Rate>
+            <Rate currency="INR">0.0596</Rate>
+            <Rate currency="JPY" multiplier="100">3.4196</Rate>
+            <Rate currency="KRW" multiplier="100">0.3558</Rate>
+            <Rate currency="MDL">0.2250</Rate>
+            <Rate currency="MXN">0.2035</Rate>
+            <Rate currency="NOK">0.4840</Rate>
+            <Rate currency="NZD">2.7770</Rate>
+            <Rate currency="PLN">1.1163</Rate>
+            <Rate currency="RSD">0.0392</Rate>
+            <Rate currency="RUB">0.0671</Rate>
+            <Rate currency="SEK">0.4733</Rate>
+            <Rate currency="THB">0.1192</Rate>
+            <Rate currency="TRY">1.0007</Rate>
+            <Rate currency="UAH">0.1321</Rate>
+            <Rate currency="USD">3.8054</Rate>
+            <Rate currency="XAU">162.6746</Rate>
+            <Rate currency="XDR">5.4782</Rate>
+            <Rate currency="ZAR">0.3100</Rate>
+        </Cube>
+        <Cube date="2018-01-19">
+            <Rate currency="AED">1.0341</Rate>
+            <Rate currency="AUD">3.0446</Rate>
+            <Rate currency="BGN">2.3834</Rate>
+            <Rate currency="BRL">1.1846</Rate>
+            <Rate currency="CAD">3.0592</Rate>
+            <Rate currency="CHF">3.9727</Rate>
+            <Rate currency="CNY">0.5937</Rate>
+            <Rate currency="CZK">0.1834</Rate>
+            <Rate currency="DKK">0.6259</Rate>
+            <Rate currency="EGP">0.2144</Rate>
+            <Rate currency="EUR">4.6614</Rate>
+            <Rate currency="GBP">5.2814</Rate>
+            <Rate currency="HRK">0.6265</Rate>
+            <Rate currency="HUF" multiplier="100">1.5077</Rate>
+            <Rate currency="INR">0.0596</Rate>
+            <Rate currency="JPY" multiplier="100">3.4322</Rate>
+            <Rate currency="KRW" multiplier="100">0.3565</Rate>
+            <Rate currency="MDL">0.2250</Rate>
+            <Rate currency="MXN">0.2042</Rate>
+            <Rate currency="NOK">0.4843</Rate>
+            <Rate currency="NZD">2.7707</Rate>
+            <Rate currency="PLN">1.1167</Rate>
+            <Rate currency="RSD">0.0393</Rate>
+            <Rate currency="RUB">0.0671</Rate>
+            <Rate currency="SEK">0.4742</Rate>
+            <Rate currency="THB">0.1191</Rate>
+            <Rate currency="TRY">1.0030</Rate>
+            <Rate currency="UAH">0.1323</Rate>
+            <Rate currency="USD">3.7984</Rate>
+            <Rate currency="XAU">163.0820</Rate>
+            <Rate currency="XDR">5.4816</Rate>
+            <Rate currency="ZAR">0.3121</Rate>
+        </Cube>
+        <Cube date="2018-01-22">
+            <Rate currency="AED">1.0361</Rate>
+            <Rate currency="AUD">3.0502</Rate>
+            <Rate currency="BGN">2.3855</Rate>
+            <Rate currency="BRL">1.1907</Rate>
+            <Rate currency="CAD">3.0525</Rate>
+            <Rate currency="CHF">3.9621</Rate>
+            <Rate currency="CNY">0.5944</Rate>
+            <Rate currency="CZK">0.1837</Rate>
+            <Rate currency="DKK">0.6267</Rate>
+            <Rate currency="EGP">0.2146</Rate>
+            <Rate currency="EUR">4.6656</Rate>
+            <Rate currency="GBP">5.2916</Rate>
+            <Rate currency="HRK">0.6276</Rate>
+            <Rate currency="HUF" multiplier="100">1.5078</Rate>
+            <Rate currency="INR">0.0596</Rate>
+            <Rate currency="JPY" multiplier="100">3.4379</Rate>
+            <Rate currency="KRW" multiplier="100">0.3560</Rate>
+            <Rate currency="MDL">0.2254</Rate>
+            <Rate currency="MXN">0.2049</Rate>
+            <Rate currency="NOK">0.4849</Rate>
+            <Rate currency="NZD">2.7809</Rate>
+            <Rate currency="PLN">1.1187</Rate>
+            <Rate currency="RSD">0.0393</Rate>
+            <Rate currency="RUB">0.0673</Rate>
+            <Rate currency="SEK">0.4743</Rate>
+            <Rate currency="THB">0.1195</Rate>
+            <Rate currency="TRY">0.9992</Rate>
+            <Rate currency="UAH">0.1317</Rate>
+            <Rate currency="USD">3.8059</Rate>
+            <Rate currency="XAU">163.1592</Rate>
+            <Rate currency="XDR">5.4899</Rate>
+            <Rate currency="ZAR">0.3162</Rate>
+        </Cube>
+        <Cube date="2018-01-23">
+            <Rate currency="AED">1.0377</Rate>
+            <Rate currency="AUD">3.0369</Rate>
+            <Rate currency="BGN">2.3867</Rate>
+            <Rate currency="BRL">1.1904</Rate>
+            <Rate currency="CAD">3.0559</Rate>
+            <Rate currency="CHF">3.9611</Rate>
+            <Rate currency="CNY">0.5951</Rate>
+            <Rate currency="CZK">0.1837</Rate>
+            <Rate currency="DKK">0.6271</Rate>
+            <Rate currency="EGP">0.2152</Rate>
+            <Rate currency="EUR">4.6679</Rate>
+            <Rate currency="GBP">5.3186</Rate>
+            <Rate currency="HRK">0.6280</Rate>
+            <Rate currency="HUF" multiplier="100">1.5063</Rate>
+            <Rate currency="INR">0.0597</Rate>
+            <Rate currency="JPY" multiplier="100">3.4451</Rate>
+            <Rate currency="KRW" multiplier="100">0.3549</Rate>
+            <Rate currency="MDL">0.2261</Rate>
+            <Rate currency="MXN">0.2032</Rate>
+            <Rate currency="NOK">0.4839</Rate>
+            <Rate currency="NZD">2.7914</Rate>
+            <Rate currency="PLN">1.1191</Rate>
+            <Rate currency="RSD">0.0394</Rate>
+            <Rate currency="RUB">0.0674</Rate>
+            <Rate currency="SEK">0.4741</Rate>
+            <Rate currency="THB">0.1197</Rate>
+            <Rate currency="TRY">1.0049</Rate>
+            <Rate currency="UAH">0.1323</Rate>
+            <Rate currency="USD">3.8116</Rate>
+            <Rate currency="XAU">163.7611</Rate>
+            <Rate currency="XDR">5.4980</Rate>
+            <Rate currency="ZAR">0.3145</Rate>
+        </Cube>
+        <Cube date="2018-01-25">
+            <Rate currency="AED">1.0236</Rate>
+            <Rate currency="AUD">3.0366</Rate>
+            <Rate currency="BGN">2.3859</Rate>
+            <Rate currency="BRL">1.1948</Rate>
+            <Rate currency="CAD">3.0531</Rate>
+            <Rate currency="CHF">3.9914</Rate>
+            <Rate currency="CNY">0.5949</Rate>
+            <Rate currency="CZK">0.1838</Rate>
+            <Rate currency="DKK">0.6269</Rate>
+            <Rate currency="EGP">0.2125</Rate>
+            <Rate currency="EUR">4.6665</Rate>
+            <Rate currency="GBP">5.3626</Rate>
+            <Rate currency="HRK">0.6280</Rate>
+            <Rate currency="HUF" multiplier="100">1.5085</Rate>
+            <Rate currency="INR">0.0591</Rate>
+            <Rate currency="JPY" multiplier="100">3.4467</Rate>
+            <Rate currency="KRW" multiplier="100">0.3541</Rate>
+            <Rate currency="MDL">0.2248</Rate>
+            <Rate currency="MXN">0.2036</Rate>
+            <Rate currency="NOK">0.4866</Rate>
+            <Rate currency="NZD">2.7666</Rate>
+            <Rate currency="PLN">1.1250</Rate>
+            <Rate currency="RSD">0.0393</Rate>
+            <Rate currency="RUB">0.0674</Rate>
+            <Rate currency="SEK">0.4757</Rate>
+            <Rate currency="THB">0.1195</Rate>
+            <Rate currency="TRY">1.0031</Rate>
+            <Rate currency="UAH">0.1308</Rate>
+            <Rate currency="USD">3.7595</Rate>
+            <Rate currency="XAU">164.3647</Rate>
+            <Rate currency="XDR">5.4708</Rate>
+            <Rate currency="ZAR">0.3163</Rate>
+        </Cube>
+        <Cube date="2018-01-26">
+            <Rate currency="AED">1.0192</Rate>
+            <Rate currency="AUD">3.0296</Rate>
+            <Rate currency="BGN">2.3856</Rate>
+            <Rate currency="BRL">1.1890</Rate>
+            <Rate currency="CAD">3.0421</Rate>
+            <Rate currency="CHF">4.0093</Rate>
+            <Rate currency="CNY">0.5923</Rate>
+            <Rate currency="CZK">0.1839</Rate>
+            <Rate currency="DKK">0.6267</Rate>
+            <Rate currency="EGP">0.2116</Rate>
+            <Rate currency="EUR">4.6658</Rate>
+            <Rate currency="GBP">5.3342</Rate>
+            <Rate currency="HRK">0.6285</Rate>
+            <Rate currency="HUF" multiplier="100">1.5065</Rate>
+            <Rate currency="INR">0.0589</Rate>
+            <Rate currency="JPY" multiplier="100">3.4319</Rate>
+            <Rate currency="KRW" multiplier="100">0.3517</Rate>
+            <Rate currency="MDL">0.2239</Rate>
+            <Rate currency="MXN">0.2021</Rate>
+            <Rate currency="NOK">0.4870</Rate>
+            <Rate currency="NZD">2.7593</Rate>
+            <Rate currency="PLN">1.1252</Rate>
+            <Rate currency="RSD">0.0393</Rate>
+            <Rate currency="RUB">0.0671</Rate>
+            <Rate currency="SEK">0.4757</Rate>
+            <Rate currency="THB">0.1193</Rate>
+            <Rate currency="TRY">1.0002</Rate>
+            <Rate currency="UAH">0.1313</Rate>
+            <Rate currency="USD">3.7436</Rate>
+            <Rate currency="XAU">163.0327</Rate>
+            <Rate currency="XDR">5.4545</Rate>
+            <Rate currency="ZAR">0.3162</Rate>
+        </Cube>
+        <Cube date="2018-01-29">
+            <Rate currency="AED">1.0202</Rate>
+            <Rate currency="AUD">3.0356</Rate>
+            <Rate currency="BGN">2.3795</Rate>
+            <Rate currency="BRL">1.1883</Rate>
+            <Rate currency="CAD">3.0358</Rate>
+            <Rate currency="CHF">4.0046</Rate>
+            <Rate currency="CNY">0.5922</Rate>
+            <Rate currency="CZK">0.1839</Rate>
+            <Rate currency="DKK">0.6253</Rate>
+            <Rate currency="EGP">0.2119</Rate>
+            <Rate currency="EUR">4.6540</Rate>
+            <Rate currency="GBP">5.2844</Rate>
+            <Rate currency="HRK">0.6276</Rate>
+            <Rate currency="HUF" multiplier="100">1.5040</Rate>
+            <Rate currency="INR">0.0590</Rate>
+            <Rate currency="JPY" multiplier="100">3.4482</Rate>
+            <Rate currency="KRW" multiplier="100">0.3508</Rate>
+            <Rate currency="MDL">0.2232</Rate>
+            <Rate currency="MXN">0.2022</Rate>
+            <Rate currency="NOK">0.4869</Rate>
+            <Rate currency="NZD">2.7480</Rate>
+            <Rate currency="PLN">1.1231</Rate>
+            <Rate currency="RSD">0.0392</Rate>
+            <Rate currency="RUB">0.0666</Rate>
+            <Rate currency="SEK">0.4753</Rate>
+            <Rate currency="THB">0.1192</Rate>
+            <Rate currency="TRY">0.9916</Rate>
+            <Rate currency="UAH">0.1328</Rate>
+            <Rate currency="USD">3.7472</Rate>
+            <Rate currency="XAU">162.4116</Rate>
+            <Rate currency="XDR">5.4496</Rate>
+            <Rate currency="ZAR">0.3132</Rate>
+        </Cube>
+        <Cube date="2018-01-30">
+            <Rate currency="AED">1.0187</Rate>
+            <Rate currency="AUD">3.0287</Rate>
+            <Rate currency="BGN">2.3762</Rate>
+            <Rate currency="BRL">1.1859</Rate>
+            <Rate currency="CAD">3.0365</Rate>
+            <Rate currency="CHF">4.0104</Rate>
+            <Rate currency="CNY">0.5919</Rate>
+            <Rate currency="CZK">0.1836</Rate>
+            <Rate currency="DKK">0.6244</Rate>
+            <Rate currency="EGP">0.2122</Rate>
+            <Rate currency="EUR">4.6474</Rate>
+            <Rate currency="GBP">5.2724</Rate>
+            <Rate currency="HRK">0.6265</Rate>
+            <Rate currency="HUF" multiplier="100">1.4993</Rate>
+            <Rate currency="INR">0.0588</Rate>
+            <Rate currency="JPY" multiplier="100">3.4456</Rate>
+            <Rate currency="KRW" multiplier="100">0.3500</Rate>
+            <Rate currency="MDL">0.2238</Rate>
+            <Rate currency="MXN">0.2010</Rate>
+            <Rate currency="NOK">0.4855</Rate>
+            <Rate currency="NZD">2.7445</Rate>
+            <Rate currency="PLN">1.1210</Rate>
+            <Rate currency="RSD">0.0391</Rate>
+            <Rate currency="RUB">0.0669</Rate>
+            <Rate currency="SEK">0.4751</Rate>
+            <Rate currency="THB">0.1191</Rate>
+            <Rate currency="TRY">0.9912</Rate>
+            <Rate currency="UAH">0.1337</Rate>
+            <Rate currency="USD">3.7416</Rate>
+            <Rate currency="XAU">161.8384</Rate>
+            <Rate currency="XDR">5.4421</Rate>
+            <Rate currency="ZAR">0.3151</Rate>
+        </Cube>
+        <Cube date="2018-01-31">
+            <Rate currency="AED">1.0194</Rate>
+            <Rate currency="AUD">3.0316</Rate>
+            <Rate currency="BGN">2.3817</Rate>
+            <Rate currency="BRL">1.1760</Rate>
+            <Rate currency="CAD">3.0491</Rate>
+            <Rate currency="CHF">4.0166</Rate>
+            <Rate currency="CNY">0.5959</Rate>
+            <Rate currency="CZK">0.1841</Rate>
+            <Rate currency="DKK">0.6259</Rate>
+            <Rate currency="EGP">0.2119</Rate>
+            <Rate currency="EUR">4.6582</Rate>
+            <Rate currency="GBP">5.2952</Rate>
+            <Rate currency="HRK">0.6267</Rate>
+            <Rate currency="HUF" multiplier="100">1.4999</Rate>
+            <Rate currency="INR">0.0589</Rate>
+            <Rate currency="JPY" multiplier="100">3.4411</Rate>
+            <Rate currency="KRW" multiplier="100">0.3512</Rate>
+            <Rate currency="MDL">0.2241</Rate>
+            <Rate currency="MXN">0.2008</Rate>
+            <Rate currency="NOK">0.4862</Rate>
+            <Rate currency="NZD">2.7707</Rate>
+            <Rate currency="PLN">1.1224</Rate>
+            <Rate currency="RSD">0.0392</Rate>
+            <Rate currency="RUB">0.0666</Rate>
+            <Rate currency="SEK">0.4769</Rate>
+            <Rate currency="THB">0.1195</Rate>
+            <Rate currency="TRY">0.9960</Rate>
+            <Rate currency="UAH">0.1345</Rate>
+            <Rate currency="USD">3.7442</Rate>
+            <Rate currency="XAU">161.6102</Rate>
+            <Rate currency="XDR">5.4533</Rate>
+            <Rate currency="ZAR">0.3160</Rate>
+        </Cube>
+        <Cube date="2018-02-01">
+            <Rate currency="AED">1.0194</Rate>
+            <Rate currency="AUD">2.9957</Rate>
+            <Rate currency="BGN">2.3802</Rate>
+            <Rate currency="BRL">1.1751</Rate>
+            <Rate currency="CAD">3.0409</Rate>
+            <Rate currency="CHF">4.0156</Rate>
+            <Rate currency="CNY">0.5947</Rate>
+            <Rate currency="CZK">0.1845</Rate>
+            <Rate currency="DKK">0.6255</Rate>
+            <Rate currency="EGP">0.2119</Rate>
+            <Rate currency="EUR">4.6551</Rate>
+            <Rate currency="GBP">5.3308</Rate>
+            <Rate currency="HRK">0.6261</Rate>
+            <Rate currency="HUF" multiplier="100">1.5009</Rate>
+            <Rate currency="INR">0.0586</Rate>
+            <Rate currency="JPY" multiplier="100">3.4151</Rate>
+            <Rate currency="KRW" multiplier="100">0.3495</Rate>
+            <Rate currency="MDL">0.2237</Rate>
+            <Rate currency="MXN">0.2011</Rate>
+            <Rate currency="NOK">0.4867</Rate>
+            <Rate currency="NZD">2.7497</Rate>
+            <Rate currency="PLN">1.1216</Rate>
+            <Rate currency="RSD">0.0392</Rate>
+            <Rate currency="RUB">0.0666</Rate>
+            <Rate currency="SEK">0.4750</Rate>
+            <Rate currency="THB">0.1194</Rate>
+            <Rate currency="TRY">0.9953</Rate>
+            <Rate currency="UAH">0.1344</Rate>
+            <Rate currency="USD">3.7443</Rate>
+            <Rate currency="XAU">161.2527</Rate>
+            <Rate currency="XDR">5.4510</Rate>
+            <Rate currency="ZAR">0.3138</Rate>
+        </Cube>
+        <Cube date="2018-02-02">
+            <Rate currency="AED">1.0146</Rate>
+            <Rate currency="AUD">2.9766</Rate>
+            <Rate currency="BGN">2.3788</Rate>
+            <Rate currency="BRL">1.1767</Rate>
+            <Rate currency="CAD">3.0293</Rate>
+            <Rate currency="CHF">4.0065</Rate>
+            <Rate currency="CNY">0.5928</Rate>
+            <Rate currency="CZK">0.1846</Rate>
+            <Rate currency="DKK">0.6251</Rate>
+            <Rate currency="EGP">0.2112</Rate>
+            <Rate currency="EUR">4.6526</Rate>
+            <Rate currency="GBP">5.3000</Rate>
+            <Rate currency="HRK">0.6258</Rate>
+            <Rate currency="HUF" multiplier="100">1.5030</Rate>
+            <Rate currency="INR">0.0582</Rate>
+            <Rate currency="JPY" multiplier="100">3.3921</Rate>
+            <Rate currency="KRW" multiplier="100">0.3435</Rate>
+            <Rate currency="MDL">0.2242</Rate>
+            <Rate currency="MXN">0.2022</Rate>
+            <Rate currency="NOK">0.4857</Rate>
+            <Rate currency="NZD">2.7405</Rate>
+            <Rate currency="PLN">1.1188</Rate>
+            <Rate currency="RSD">0.0392</Rate>
+            <Rate currency="RUB">0.0662</Rate>
+            <Rate currency="SEK">0.4736</Rate>
+            <Rate currency="THB">0.1187</Rate>
+            <Rate currency="TRY">0.9921</Rate>
+            <Rate currency="UAH">0.1338</Rate>
+            <Rate currency="USD">3.7266</Rate>
+            <Rate currency="XAU">161.1758</Rate>
+            <Rate currency="XDR">5.4323</Rate>
+            <Rate currency="ZAR">0.3116</Rate>
+        </Cube>
+        <Cube date="2018-02-05">
+            <Rate currency="AED">1.0120</Rate>
+            <Rate currency="AUD">2.9519</Rate>
+            <Rate currency="BGN">2.3697</Rate>
+            <Rate currency="BRL">1.1549</Rate>
+            <Rate currency="CAD">2.9947</Rate>
+            <Rate currency="CHF">3.9975</Rate>
+            <Rate currency="CNY">0.5910</Rate>
+            <Rate currency="CZK">0.1839</Rate>
+            <Rate currency="DKK">0.6227</Rate>
+            <Rate currency="EGP">0.2104</Rate>
+            <Rate currency="EUR">4.6347</Rate>
+            <Rate currency="GBP">5.2467</Rate>
+            <Rate currency="HRK">0.6234</Rate>
+            <Rate currency="HUF" multiplier="100">1.4958</Rate>
+            <Rate currency="INR">0.0580</Rate>
+            <Rate currency="JPY" multiplier="100">3.3848</Rate>
+            <Rate currency="KRW" multiplier="100">0.3421</Rate>
+            <Rate currency="MDL">0.2226</Rate>
+            <Rate currency="MXN">0.2002</Rate>
+            <Rate currency="NOK">0.4822</Rate>
+            <Rate currency="NZD">2.7193</Rate>
+            <Rate currency="PLN">1.1149</Rate>
+            <Rate currency="RSD">0.0391</Rate>
+            <Rate currency="RUB">0.0657</Rate>
+            <Rate currency="SEK">0.4715</Rate>
+            <Rate currency="THB">0.1179</Rate>
+            <Rate currency="TRY">0.9871</Rate>
+            <Rate currency="UAH">0.1341</Rate>
+            <Rate currency="USD">3.7170</Rate>
+            <Rate currency="XAU">159.8479</Rate>
+            <Rate currency="XDR">5.4124</Rate>
+            <Rate currency="ZAR">0.3090</Rate>
+        </Cube>
+        <Cube date="2018-02-06">
+            <Rate currency="AED">1.0191</Rate>
+            <Rate currency="AUD">2.9459</Rate>
+            <Rate currency="BGN">2.3736</Rate>
+            <Rate currency="BRL">1.1473</Rate>
+            <Rate currency="CAD">2.9901</Rate>
+            <Rate currency="CHF">4.0046</Rate>
+            <Rate currency="CNY">0.5965</Rate>
+            <Rate currency="CZK">0.1841</Rate>
+            <Rate currency="DKK">0.6237</Rate>
+            <Rate currency="EGP">0.2126</Rate>
+            <Rate currency="EUR">4.6423</Rate>
+            <Rate currency="GBP">5.2263</Rate>
+            <Rate currency="HRK">0.6243</Rate>
+            <Rate currency="HUF" multiplier="100">1.4959</Rate>
+            <Rate currency="INR">0.0583</Rate>
+            <Rate currency="JPY" multiplier="100">3.4310</Rate>
+            <Rate currency="KRW" multiplier="100">0.3444</Rate>
+            <Rate currency="MDL">0.2243</Rate>
+            <Rate currency="MXN">0.1995</Rate>
+            <Rate currency="NOK">0.4795</Rate>
+            <Rate currency="NZD">2.7349</Rate>
+            <Rate currency="PLN">1.1169</Rate>
+            <Rate currency="RSD">0.0391</Rate>
+            <Rate currency="RUB">0.0655</Rate>
+            <Rate currency="SEK">0.4710</Rate>
+            <Rate currency="THB">0.1186</Rate>
+            <Rate currency="TRY">0.9905</Rate>
+            <Rate currency="UAH">0.1350</Rate>
+            <Rate currency="USD">3.7433</Rate>
+            <Rate currency="XAU">161.6750</Rate>
+            <Rate currency="XDR">5.4401</Rate>
+            <Rate currency="ZAR">0.3104</Rate>
+        </Cube>
+        <Cube date="2018-02-07">
+            <Rate currency="AED">1.0265</Rate>
+            <Rate currency="AUD">2.9639</Rate>
+            <Rate currency="BGN">2.3795</Rate>
+            <Rate currency="BRL">1.1656</Rate>
+            <Rate currency="CAD">3.0101</Rate>
+            <Rate currency="CHF">4.0110</Rate>
+            <Rate currency="CNY">0.6016</Rate>
+            <Rate currency="CZK">0.1844</Rate>
+            <Rate currency="DKK">0.6253</Rate>
+            <Rate currency="EGP">0.2136</Rate>
+            <Rate currency="EUR">4.6538</Rate>
+            <Rate currency="GBP">5.2360</Rate>
+            <Rate currency="HRK">0.6255</Rate>
+            <Rate currency="HUF" multiplier="100">1.5012</Rate>
+            <Rate currency="INR">0.0587</Rate>
+            <Rate currency="JPY" multiplier="100">3.4558</Rate>
+            <Rate currency="KRW" multiplier="100">0.3479</Rate>
+            <Rate currency="MDL">0.2263</Rate>
+            <Rate currency="MXN">0.2016</Rate>
+            <Rate currency="NOK">0.4811</Rate>
+            <Rate currency="NZD">2.7551</Rate>
+            <Rate currency="PLN">1.1183</Rate>
+            <Rate currency="RSD">0.0392</Rate>
+            <Rate currency="RUB">0.0659</Rate>
+            <Rate currency="SEK">0.4719</Rate>
+            <Rate currency="THB">0.1194</Rate>
+            <Rate currency="TRY">0.9969</Rate>
+            <Rate currency="UAH">0.1391</Rate>
+            <Rate currency="USD">3.7705</Rate>
+            <Rate currency="XAU">160.9952</Rate>
+            <Rate currency="XDR">5.4695</Rate>
+            <Rate currency="ZAR">0.3155</Rate>
+        </Cube>
+        <Cube date="2018-02-08">
+            <Rate currency="AED">1.0352</Rate>
+            <Rate currency="AUD">2.9704</Rate>
+            <Rate currency="BGN">2.3792</Rate>
+            <Rate currency="BRL">1.1623</Rate>
+            <Rate currency="CAD">3.0205</Rate>
+            <Rate currency="CHF">4.0203</Rate>
+            <Rate currency="CNY">0.6012</Rate>
+            <Rate currency="CZK">0.1843</Rate>
+            <Rate currency="DKK">0.6252</Rate>
+            <Rate currency="EGP">0.2148</Rate>
+            <Rate currency="EUR">4.6533</Rate>
+            <Rate currency="GBP">5.2812</Rate>
+            <Rate currency="HRK">0.6253</Rate>
+            <Rate currency="HUF" multiplier="100">1.4957</Rate>
+            <Rate currency="INR">0.0592</Rate>
+            <Rate currency="JPY" multiplier="100">3.4683</Rate>
+            <Rate currency="KRW" multiplier="100">0.3483</Rate>
+            <Rate currency="MDL">0.2271</Rate>
+            <Rate currency="MXN">0.2026</Rate>
+            <Rate currency="NOK">0.4803</Rate>
+            <Rate currency="NZD">2.7454</Rate>
+            <Rate currency="PLN">1.1160</Rate>
+            <Rate currency="RSD">0.0392</Rate>
+            <Rate currency="RUB">0.0657</Rate>
+            <Rate currency="SEK">0.4702</Rate>
+            <Rate currency="THB">0.1194</Rate>
+            <Rate currency="TRY">0.9960</Rate>
+            <Rate currency="UAH">0.1403</Rate>
+            <Rate currency="USD">3.8025</Rate>
+            <Rate currency="XAU">160.2321</Rate>
+            <Rate currency="XDR">5.4928</Rate>
+            <Rate currency="ZAR">0.3135</Rate>
+        </Cube>
+        <Cube date="2018-02-09">
+            <Rate currency="AED">1.0341</Rate>
+            <Rate currency="AUD">2.9599</Rate>
+            <Rate currency="BGN">2.3806</Rate>
+            <Rate currency="BRL">1.1558</Rate>
+            <Rate currency="CAD">3.0136</Rate>
+            <Rate currency="CHF">4.0511</Rate>
+            <Rate currency="CNY">0.6030</Rate>
+            <Rate currency="CZK">0.1838</Rate>
+            <Rate currency="DKK">0.6255</Rate>
+            <Rate currency="EGP">0.2148</Rate>
+            <Rate currency="EUR">4.6561</Rate>
+            <Rate currency="GBP">5.2844</Rate>
+            <Rate currency="HRK">0.6251</Rate>
+            <Rate currency="HUF" multiplier="100">1.4923</Rate>
+            <Rate currency="INR">0.0590</Rate>
+            <Rate currency="JPY" multiplier="100">3.4800</Rate>
+            <Rate currency="KRW" multiplier="100">0.3498</Rate>
+            <Rate currency="MDL">0.2291</Rate>
+            <Rate currency="MXN">0.2023</Rate>
+            <Rate currency="NOK">0.4728</Rate>
+            <Rate currency="NZD">2.7461</Rate>
+            <Rate currency="PLN">1.1107</Rate>
+            <Rate currency="RSD">0.0393</Rate>
+            <Rate currency="RUB">0.0655</Rate>
+            <Rate currency="SEK">0.4670</Rate>
+            <Rate currency="THB">0.1195</Rate>
+            <Rate currency="TRY">0.9938</Rate>
+            <Rate currency="UAH">0.1405</Rate>
+            <Rate currency="USD">3.7984</Rate>
+            <Rate currency="XAU">160.6002</Rate>
+            <Rate currency="XDR">5.4950</Rate>
+            <Rate currency="ZAR">0.3141</Rate>
+        </Cube>
+    </Body>
+</DataSet>

--- a/tests/Tests/Service/NationalBankOfRomaniaTest.php
+++ b/tests/Tests/Service/NationalBankOfRomaniaTest.php
@@ -85,4 +85,21 @@ class NationalBankOfRomaniaTest extends ServiceTestCase
         $this->assertSame('0.014356', $rate->getValue());
         $this->assertEquals(new \DateTime('2016-12-02'), $rate->getDate());
     }
+
+    /**
+     * @test
+     */
+    public function it_fetches_a_historical_rate()
+    {
+        $url = 'http://www.bnr.ro/files/xml/years/nbrfxrates2018.xml';
+        $content = file_get_contents(__DIR__.'/../../Fixtures/Service/NationalBankOfRomania/nbrfxrates2018.xml');
+
+        $service = new NationalBankOfRomania($this->getHttpAdapterMock($url, $content));
+        $rate = $service->getExchangeRate(
+            new HistoricalExchangeRateQuery(CurrencyPair::createFromString('EUR/RON'), new \DateTime('2018-02-02'))
+        );
+
+        $this->assertSame('4.6526', $rate->getValue());
+        $this->assertEquals(new \DateTime('2018-02-02'), $rate->getDate());
+    }
 }


### PR DESCRIPTION
I've extended `NationalBankOfRomania.php` service to support historical data. The existing test for BNR to reflect code changes/additions. 