### PR TITLE
Added support currency nominal for Russian Central Bank

### DIFF
--- a/src/Service/RussianCentralBank.php
+++ b/src/Service/RussianCentralBank.php
@@ -33,9 +33,10 @@ class RussianCentralBank extends HistoricalService
             throw new UnsupportedCurrencyPairException($exchangeQuery->getCurrencyPair(), $this);
         }
 
-        $rate = str_replace(',', '.', (string) ($elements['0']->Value / $elements['0']->Nominal));
+        $rate = str_replace(',', '.', (string) $elements['0']->Value);
+        $nominal = str_replace(',', '.', (string) $elements['0']->Nominal);
 
-        return new ExchangeRate($rate, $date);
+        return new ExchangeRate($rate / $nominal, $date);
     }
 
     /**
@@ -59,9 +60,10 @@ class RussianCentralBank extends HistoricalService
             throw new UnsupportedCurrencyPairException($exchangeQuery->getCurrencyPair(), $this);
         }
 
-        $rate = str_replace(',', '.', (string) ($elements['0']->Value / $elements['0']->Nominal));
+        $rate = str_replace(',', '.', (string) $elements['0']->Value);
+        $nominal = str_replace(',', '.', (string) $elements['0']->Nominal);
 
-        return new ExchangeRate($rate, $exchangeQuery->getDate());
+        return new ExchangeRate($rate / $nominal, $exchangeQuery->getDate());
     }
 
     /**

--- a/src/Service/RussianCentralBank.php
+++ b/src/Service/RussianCentralBank.php
@@ -33,7 +33,7 @@ class RussianCentralBank extends HistoricalService
             throw new UnsupportedCurrencyPairException($exchangeQuery->getCurrencyPair(), $this);
         }
 
-        $rate = str_replace(',', '.', (string) $elements['0']->Value);
+        $rate = str_replace(',', '.', (string) ($elements['0']->Value / $elements['0']->Nominal));
 
         return new ExchangeRate($rate, $date);
     }
@@ -59,7 +59,7 @@ class RussianCentralBank extends HistoricalService
             throw new UnsupportedCurrencyPairException($exchangeQuery->getCurrencyPair(), $this);
         }
 
-        $rate = str_replace(',', '.', (string) $elements['0']->Value);
+        $rate = str_replace(',', '.', (string) ($elements['0']->Value / $elements['0']->Nominal));
 
         return new ExchangeRate($rate, $exchangeQuery->getDate());
     }

--- a/tests/Tests/Service/RussianCentralBankTest.php
+++ b/tests/Tests/Service/RussianCentralBankTest.php
@@ -62,6 +62,21 @@ class RussianCentralBankTest extends ServiceTestCase
     /**
      * @test
      */
+    public function it_fetches_a_nominational_rate()
+    {
+        $url = 'http://www.cbr.ru/scripts/XML_daily.asp';
+        $content = file_get_contents(__DIR__.'/../../Fixtures/Service/RussianCentralBank/success.xml');
+
+        $service = new RussianCentralBank($this->getHttpAdapterMock($url, $content));
+        $rate = $service->getExchangeRate(new ExchangeRateQuery(CurrencyPair::createFromString('AMD/RUB')));
+
+        $this->assertSame('0.131783', $rate->getValue());
+        $this->assertEquals(new \DateTime('2016-12-09'), $rate->getDate());
+    }
+
+    /**
+     * @test
+     */
     public function it_fetches_a_historical_rate()
     {
         $url = 'http://www.cbr.ru/scripts/XML_daily.asp?date_req=23.08.2016';


### PR DESCRIPTION
Hi!
Russian Central Bank returns some currencies for nominal 10, 100 or more:
`<Valute ID="R01535">
<NumCode>578</NumCode>
<CharCode>NOK</CharCode>
<Nominal>10</Nominal>
<Name>Норвежских крон</Name>
<Value>72,9379</Value>
</Valute>`

I added support for this.