### PR TITLE
Correct new fixer.io API urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Here is the list of the currently implemented services.
 
 | Service | Base Currency | Quote Currency | Historical |
 |---------------------------------------------------------------------------|----------------------|----------------|----------------|
-| [Fixer](http://fixer.io) | * | * | Yes |
+| [Fixer](http://fixer.io) | EUR (free, no SSL), * (paid) | * | Yes |
 | [European Central Bank](http://www.ecb.europa.eu/home/html/index.en.html) | EUR | * | Yes |
 | [Google](http://www.google.com/finance) | * | * | No |
 | [Open Exchange Rates](https://openexchangerates.org) | USD (free), * (paid) | * | Yes |

--- a/src/Service/Fixer.php
+++ b/src/Service/Fixer.php
@@ -27,8 +27,8 @@ class Fixer extends HistoricalService
 {
     const ACCESS_KEY_OPTION = 'access_key';
 
-    const LATEST_URL = 'https://api.fixer.io/latest?base=%s&access_key=%s';
-    const HISTORICAL_URL = 'https://api.fixer.io/%s?base=%s&access_key=%s';
+    const LATEST_URL = 'http://data.fixer.io/api/latest?base=%s&access_key=%s';
+    const HISTORICAL_URL = 'http://data.fixer.io/api/%s?base=%s&access_key=%s';
 
     /**
      * {@inheritdoc}

--- a/tests/Tests/Service/FixerTest.php
+++ b/tests/Tests/Service/FixerTest.php
@@ -34,7 +34,7 @@ class FixerTest extends ServiceTestCase
      */
     public function it_throws_an_exception_with_error_response()
     {
-        $uri = 'https://api.fixer.io/latest?base=USD&access_key=x';
+        $uri = 'http://data.fixer.io/api/latest?base=USD&access_key=x';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/Fixer/error.json');
 
         $service = new Fixer($this->getHttpAdapterMock($uri, $content), null, ['access_key' => 'x']);
@@ -46,7 +46,7 @@ class FixerTest extends ServiceTestCase
      */
     public function it_fetches_a_rate()
     {
-        $uri = 'https://api.fixer.io/latest?base=EUR&access_key=x';
+        $uri = 'http://data.fixer.io/api/latest?base=EUR&access_key=x';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/Fixer/latest.json');
 
         $service = new Fixer($this->getHttpAdapterMock($uri, $content), null, ['access_key' => 'x']);
@@ -61,7 +61,7 @@ class FixerTest extends ServiceTestCase
      */
     public function it_fetches_a_historical_rate()
     {
-        $uri = 'https://api.fixer.io/2000-01-03?base=USD&access_key=x';
+        $uri = 'http://data.fixer.io/api/2000-01-03?base=USD&access_key=x';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/Fixer/historical.json');
         $date = new \DateTime('2000-01-03');
 


### PR DESCRIPTION
@florianv idk what I was doing in #44 - it is completely bogus as I didn't use the updated URL. So with the previous change, we were using the old API with extra `access_key` parameter that was just ignored.

The new Fixer.io Free API imho is terrible - besides imposing API limit, they have disabled the SSL in order to up-sell their paid plans. I'm pushing this to not leave it half done, otherwise I'll just avoid them.