### PR TITLE
#55 - validation for Forge API response

### DIFF
--- a/src/Service/Forge.php
+++ b/src/Service/Forge.php
@@ -39,16 +39,18 @@ class Forge extends Service
     public function getExchangeRate(ExchangeRateQuery $exchangeRateQuery)
     {
         $currencyPair = $exchangeRateQuery->getCurrencyPair();
-        $url = sprintf(self::URL, $currencyPair->getBaseCurrency().$currencyPair->getQuoteCurrency(), $this->options['api_key']);
+        $currencySymbol = $currencyPair->getBaseCurrency().$currencyPair->getQuoteCurrency();
+        $url = sprintf(self::URL, $currencySymbol, $this->options['api_key']);
 
         $content = $this->request($url);
-
         $data = StringUtil::jsonToArray($content);
 
-        if (!empty($data)) {
-            $date = (new \DateTime())->setTimestamp($data[0]['timestamp']);
+        if ($result = reset($data)) {
+            $date = (new \DateTime())->setTimestamp($result['timestamp']);
 
-            return new ExchangeRate($data[0]['price'], $date);
+            if ($result['symbol'] == $currencySymbol) {
+                return new ExchangeRate($result['price'], $date);
+            }
         }
 
         throw new UnsupportedCurrencyPairException($currencyPair, $this);

--- a/tests/Fixtures/Service/Forge/multiple.json
+++ b/tests/Fixtures/Service/Forge/multiple.json
@@ -1,0 +1,1 @@
+[{"symbol":"EURHKD","bid":9.12753,"ask":9.1269,"price":9.12721,"timestamp":1527683396},{"symbol":"EURCNH","bid":7.45606,"ask":7.45577,"price":7.45591,"timestamp":1527683396}]

--- a/tests/Tests/Service/ForgeTest.php
+++ b/tests/Tests/Service/ForgeTest.php
@@ -47,4 +47,31 @@ class ForgeTest extends ServiceTestCase
         $this->assertSame('1.18711', $rate->getValue());
         $this->assertTrue('2017-12-21' == $rate->getDate()->format('Y-m-d'));
     }
+
+    /**
+     * @test
+     */
+    public function it_fetches_a_rate_when_response_symbol_matches()
+    {
+        $url = 'https://forex.1forge.com/latest/quotes?pairs=EURHKD&api_key=secret';
+        $content = file_get_contents(__DIR__.'/../../Fixtures/Service/Forge/multiple.json');
+        $service = new Forge($this->getHttpAdapterMock($url, $content), null, ['api_key' => 'secret']);
+
+        $rate = $service->getExchangeRate(new ExchangeRateQuery(CurrencyPair::createFromString('EUR/HKD')));
+        $this->assertSame('9.12721', $rate->getValue());
+        $this->assertTrue('2018-05-30' == $rate->getDate()->format('Y-m-d'));
+    }
+
+    /**
+     * @test
+     * @expectedException \Exchanger\Exception\Exception
+     */
+    public function it_throws_an_exception_when_response_symbol_does_not_match()
+    {
+        $url = 'https://forex.1forge.com/latest/quotes?pairs=USDAED&api_key=secret';
+        $content = file_get_contents(__DIR__.'/../../Fixtures/Service/Forge/multiple.json');
+        $service = new Forge($this->getHttpAdapterMock($url, $content), null, ['api_key' => 'secret']);
+
+        $service->getExchangeRate(new ExchangeRateQuery(CurrencyPair::createFromString('USD/AED')));
+    }
 }


### PR DESCRIPTION
As per #55,
I think we should validate the response currency symbol, instead of just return the first value in the case when it doesn't match we get invalid values.