### PR TITLE
Support HTTPlug 2.0 clients and PSR-18

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": "^7.1.3",
-        "php-http/httplug": "^1.0",
+        "php-http/httplug": "^1.0 || ^2.0",
         "php-http/discovery": "^1.4",
         "php-http/message-factory": "^1.0",
         "php-http/client-implementation": "^1.0",


### PR DESCRIPTION
This is a backwards compatible way of support PSR-18 and HTTPlug 2.0

FYI @gmponos
