### PR TITLE
Fixed CurrencyConverter service free API

### DIFF
--- a/src/Service/CurrencyConverter.php
+++ b/src/Service/CurrencyConverter.php
@@ -33,11 +33,11 @@ final class CurrencyConverter extends HttpService
 {
     use SupportsHistoricalQueries;
 
-    const FREE_LATEST_URL = 'https://free.currencyconverterapi.com/api/v6/convert?q=%s';
+    const FREE_LATEST_URL = 'https://free.currencyconverterapi.com/api/v6/convert?q=%s&apiKey=%s';
 
     const ENTERPRISE_LATEST_URL = 'https://api.currencyconverterapi.com/api/v6/convert?q=%s&apiKey=%s';
 
-    const FREE_HISTORICAL_URL = 'https://free.currencyconverterapi.com/api/v6/convert?q=%s&date=%s';
+    const FREE_HISTORICAL_URL = 'https://free.currencyconverterapi.com/api/v6/convert?q=%s&date=%s&apiKey=%s';
 
     const ENTERPRISE_HISTORICAL_URL = 'https://api.currencyconverterapi.com/api/v6/convert?q=%s&date=%s&apiKey=%s';
 
@@ -50,7 +50,7 @@ final class CurrencyConverter extends HttpService
             $options['enterprise'] = false;
         }
 
-        if ($options['enterprise'] && !isset($options['access_key'])) {
+        if (!isset($options['access_key'])) {
             throw new \InvalidArgumentException('The "access_key" option must be provided.');
         }
     }
@@ -95,7 +95,8 @@ final class CurrencyConverter extends HttpService
         } else {
             $url = sprintf(
                 self::FREE_LATEST_URL,
-                $this->stringifyCurrencyPair($exchangeQuery->getCurrencyPair())
+                $this->stringifyCurrencyPair($exchangeQuery->getCurrencyPair()),
+                $this->options['access_key']
             );
         }
 
@@ -126,7 +127,8 @@ final class CurrencyConverter extends HttpService
             $url = sprintf(
                 self::FREE_HISTORICAL_URL,
                 $this->stringifyCurrencyPair($exchangeQuery->getCurrencyPair()),
-                $historicalDateTime->format('Y-m-d')
+                $historicalDateTime->format('Y-m-d'),
+                $this->options['access_key']
             );
         }
 

--- a/tests/Tests/Service/CurrencyConverterTest.php
+++ b/tests/Tests/Service/CurrencyConverterTest.php
@@ -43,7 +43,7 @@ class CurrencyConverterTest extends TestCase
         $uri = 'https://free.currencyconverterapi.com/api/v6/convert?q=XXX_YYY&date=2000-01-01';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/CurrencyConverter/error.json');
 
-        $service = new CurrencyConverter($this->getHttpAdapterMock($uri, $content, 200));
+        $service = new CurrencyConverter($this->getHttpAdapterMock($uri, $content, 200), null, ['access_key' => 'secret']);
         $service->getExchangeRate(new ExchangeRateQuery(CurrencyPair::createFromString('XXX/YYY')));
     }
 
@@ -54,7 +54,7 @@ class CurrencyConverterTest extends TestCase
         $uri = 'https://free.currencyconverterapi.com/api/v6/convert?q=USD_EUR';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/CurrencyConverter/success.json');
 
-        $service = new CurrencyConverter($this->getHttpAdapterMock($uri, $content, 200));
+        $service = new CurrencyConverter($this->getHttpAdapterMock($uri, $content, 200), null, ['access_key' => 'secret']);
         $rate = $service->getExchangeRate(new ExchangeRateQuery($pair));
 
         $this->assertSame(0.726804, $rate->getValue());


### PR DESCRIPTION
CurrencyConverter API now requires 'api_key' for free queries.