### PR TITLE
PhpArray does not check if the conversion is supported

### DIFF
--- a/src/Service/PhpArray.php
+++ b/src/Service/PhpArray.php
@@ -62,15 +62,15 @@ final class PhpArray extends Service
     {
         $currencyPair = $exchangeQuery->getCurrencyPair();
 
-        if ($exchangeQuery instanceof HistoricalExchangeRateQuery) {
-            if ($rate = $this->getHistoricalExchangeRate($exchangeQuery)) {
-                return $rate;
-            }
-        } elseif ($rate = $this->getLatestExchangeRate($exchangeQuery)) {
-            return $rate;
+        if (!$this->supportQuery($exchangeQuery)) {
+            throw new UnsupportedCurrencyPairException($currencyPair, $this);
         }
 
-        throw new UnsupportedCurrencyPairException($currencyPair, $this);
+        if ($exchangeQuery instanceof HistoricalExchangeRateQuery) {
+            return $this->getHistoricalExchangeRate($exchangeQuery);
+        }
+
+        return $this->getLatestExchangeRate($exchangeQuery);
     }
 
     /**


### PR DESCRIPTION
`PhpArray` does not check if the conversion is supported. Configuring `swap/swap` with a PhpArray and then calling `->latest()` with an unsupported currency pair gives:

```
ErrorException : Undefined index: AFN/EUR
 /var/www/xxxxxx/vendor/florianv/exchanger/src/Service/PhpArray.php:86
 /var/www/xxxxxx/vendor/florianv/exchanger/src/Service/PhpArray.php:69
 /var/www/xxxxxx/vendor/florianv/swap/src/Swap.php:94
 /var/www/xxxxxx/vendor/florianv/swap/src/Swap.php:54
... some more application layer stack
```

Caller:
```
            $exchange_rate = $this->swap->latest( "{$baseCurrency}/{$counterCurrency}");
```

I also removed some if statements that were unneeded because the methods could not return a non-truthy value. 