### PR TITLE
Central bank of czech republic url fix

### DIFF
--- a/src/Service/CentralBankOfCzechRepublic.php
+++ b/src/Service/CentralBankOfCzechRepublic.php
@@ -29,7 +29,7 @@ final class CentralBankOfCzechRepublic extends HttpService
 {
     use SupportsHistoricalQueries;
 
-    const URL = 'http://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.txt';
+    const URL = 'https://www.cnb.cz/cs/financni-trhy/devizovy-trh/kurzy-devizoveho-trhu/kurzy-devizoveho-trhu/denni_kurz.txt';
 
     const DATE_FORMAT = 'd.m.Y';
 

--- a/src/Service/CentralBankOfCzechRepublic.php
+++ b/src/Service/CentralBankOfCzechRepublic.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Exchanger\Service;
 
+use DateTimeImmutable;
 use DateTimeInterface;
 use Exchanger\Contract\ExchangeRateQuery;
 use Exchanger\Contract\HistoricalExchangeRateQuery;
@@ -42,7 +43,7 @@ final class CentralBankOfCzechRepublic extends HttpService
      */
     protected function getLatestExchangeRate(ExchangeRateQuery $exchangeQuery): ExchangeRateContract
     {
-        return $this->doCreateRate($exchangeQuery);
+        return $this->doCreateRate($exchangeQuery, new DateTimeImmutable());
     }
 
     /**
@@ -71,7 +72,7 @@ final class CentralBankOfCzechRepublic extends HttpService
      *
      * @throws UnsupportedCurrencyPairException
      */
-    private function doCreateRate(ExchangeRateQuery $exchangeQuery, DateTimeInterface $requestedDate = null): ExchangeRate
+    private function doCreateRate(ExchangeRateQuery $exchangeQuery, DateTimeInterface $requestedDate): ExchangeRate
     {
         $currencyPair = $exchangeQuery->getCurrencyPair();
         $content = $this->request($this->buildUrl($requestedDate));
@@ -114,16 +115,12 @@ final class CentralBankOfCzechRepublic extends HttpService
     }
 
     /**
-     * @param DateTimeInterface|null $requestedDate
+     * @param DateTimeInterface $requestedDate
      *
      * @return string
      */
-    private function buildUrl(DateTimeInterface $requestedDate = null): string
+    private function buildUrl(DateTimeInterface $requestedDate): string
     {
-        if (null === $requestedDate) {
-            return self::URL;
-        }
-
         return self::URL.'?'.http_build_query([self::DATE_QUERY_PARAMETER_NAME => $requestedDate->format(self::DATE_FORMAT)]);
     }
 

--- a/tests/Tests/Service/CentralBankOfCzechRepublicTest.php
+++ b/tests/Tests/Service/CentralBankOfCzechRepublicTest.php
@@ -48,8 +48,8 @@ class CentralBankOfCzechRepublicTest extends ServiceTestCase
      */
     public static function setUpBeforeClass()
     {
-        self::$url = 'http://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.txt';
-        self::$historicalUrl = 'http://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.txt?date=23.04.2000';
+        self::$url = 'https://www.cnb.cz/cs/financni-trhy/devizovy-trh/kurzy-devizoveho-trhu/kurzy-devizoveho-trhu/denni_kurz.txt';
+        self::$historicalUrl = 'https://www.cnb.cz/cs/financni-trhy/devizovy-trh/kurzy-devizoveho-trhu/kurzy-devizoveho-trhu/denni_kurz.txt?date=23.04.2000';
         self::$content = file_get_contents(__DIR__.'/../../Fixtures/Service/CentralBankOfCzechRepublic/cnb_today.txt');
         self::$historicalContent = file_get_contents(__DIR__.'/../../Fixtures/Service/CentralBankOfCzechRepublic/cnb_historical.txt');
     }

--- a/tests/Tests/Service/CentralBankOfCzechRepublicTest.php
+++ b/tests/Tests/Service/CentralBankOfCzechRepublicTest.php
@@ -48,7 +48,7 @@ class CentralBankOfCzechRepublicTest extends ServiceTestCase
      */
     public static function setUpBeforeClass()
     {
-        self::$url = 'https://www.cnb.cz/cs/financni-trhy/devizovy-trh/kurzy-devizoveho-trhu/kurzy-devizoveho-trhu/denni_kurz.txt';
+        self::$url = 'https://www.cnb.cz/cs/financni-trhy/devizovy-trh/kurzy-devizoveho-trhu/kurzy-devizoveho-trhu/denni_kurz.txt?date='.date('d.m.Y');
         self::$historicalUrl = 'https://www.cnb.cz/cs/financni-trhy/devizovy-trh/kurzy-devizoveho-trhu/kurzy-devizoveho-trhu/denni_kurz.txt?date=23.04.2000';
         self::$content = file_get_contents(__DIR__.'/../../Fixtures/Service/CentralBankOfCzechRepublic/cnb_today.txt');
         self::$historicalContent = file_get_contents(__DIR__.'/../../Fixtures/Service/CentralBankOfCzechRepublic/cnb_historical.txt');


### PR DESCRIPTION
- The exchange rates source URL has changed, CNB is now using https.
- The CNB no longer supports queries without a date parameter. So we use
the current date.