### PR TITLE
Avoid returning non valid Exchanger from the cache

### DIFF
--- a/src/Exchanger.php
+++ b/src/Exchanger.php
@@ -95,7 +95,7 @@ final class Exchanger implements ExchangeRateProviderContract
 
         $item = $this->cache->get($cacheKey);
 
-        if (null !== $item) {
+        if (null !== $item && $item instanceof ExchangeRateContract) {
             return $item;
         }
 


### PR DESCRIPTION
For some reason, after updating this library, i got a strange issue:

```Return value of Exchanger\Exchanger::getExchangeRate() must be an instance of Exchanger\Contract\ExchangeRate, string returned```

Somehow, my cached exchanger wasn't returning a class, but a string.
This check makes sure that the cached valued is correct before returning it, otherwise it forces a recaching.