### PR TITLE
Fully support generators for Chain

### DIFF
--- a/src/Service/Chain.php
+++ b/src/Service/Chain.php
@@ -28,7 +28,7 @@ final class Chain implements ExchangeRateService
     /**
      * The services.
      *
-     * @var array
+     * @var array|ExchangeRateService[]
      */
     private $services;
 

--- a/src/Service/Chain.php
+++ b/src/Service/Chain.php
@@ -39,6 +39,11 @@ final class Chain implements ExchangeRateService
      */
     public function __construct(iterable $services = [])
     {
+        if (!is_array($services)) {
+            /** @var \Iterator $services */
+            $services = iterator_to_array($services);
+        }
+
         $this->services = $services;
     }
 

--- a/tests/Tests/Service/ChainTest.php
+++ b/tests/Tests/Service/ChainTest.php
@@ -180,24 +180,23 @@ class ChainTest extends TestCase
      */
     public function it_can_convert_multiple_times()
     {
-        $generator = function(): \Generator
-        {
+        $generator = function (): \Generator {
             $serviceOne = $this->createMock(ExchangeRateService::class);
             $serviceOne
-                ->method("supportQuery")
+                ->method('supportQuery')
                 ->willReturn(false);
 
             yield $serviceOne;
 
             $serviceTwo = $this->createMock(ExchangeRateService::class);
             $serviceTwo
-                ->method("supportQuery")
+                ->method('supportQuery')
                 ->willReturn(true);
 
-            $exchangeRate = new ExchangeRate(CurrencyPair::createFromString("EUR/USD"), 0.8, new \DateTimeImmutable(), "mock");
+            $exchangeRate = new ExchangeRate(CurrencyPair::createFromString('EUR/USD'), 0.8, new \DateTimeImmutable(), 'mock');
 
             $serviceTwo->expects($this->exactly(2))
-                ->method("getExchangeRate")
+                ->method('getExchangeRate')
                 ->willReturn($exchangeRate);
 
             yield $serviceTwo;


### PR DESCRIPTION
This fully supports generators and allows to iterate multiple times over the services, even if they were passed through a generator. 

I looked into using `CachingIterator` but it would require to be rewound before every iteration, additionally it seems to call the next value of the iterator a bit too early. 

Follows #111.