### PR TITLE
Update ChainException to support Throwables

### DIFF
--- a/src/Exception/ChainException.php
+++ b/src/Exception/ChainException.php
@@ -34,7 +34,7 @@ final class ChainException extends Exception
      */
     public function __construct(array $exceptions)
     {
-        $messages = array_map(function (\Exception $exception) {
+        $messages = array_map(function (\Throwable $exception) {
             return sprintf(
                 '%s: %s',
                 get_class($exception),


### PR DESCRIPTION
Fixes issue where TypeErrors, etc, would cause an exception without the relevant messages shown