### PR TITLE
Code adapted to PHP 8; upgrade to PHPUnit 9.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ matrix:
         - php: 7.2
         - php: 7.3
         - php: 7.4
+        - php: 8.0
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "ext-simplexml": "*",
-        "php": "^7.1.3",
+        "php": "^7.1.3 || ^8.0",
         "php-http/httplug": "^1.0 || ^2.0",
         "php-http/discovery": "^1.6",
         "php-http/message-factory": "^1.0.2",
@@ -32,7 +32,7 @@
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^9.4",
         "php-http/message": "^1.7",
         "php-http/mock-client": "^1.0",
         "nyholm/psr7": "^1.0"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "psr/simple-cache": "^1.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4",
+        "phpunit/phpunit": "^7 || ^8 || ^9.4",
         "php-http/message": "^1.7",
         "php-http/mock-client": "^1.0",
         "nyholm/psr7": "^1.0"

--- a/src/StringUtil.php
+++ b/src/StringUtil.php
@@ -23,11 +23,7 @@ final class StringUtil
     /**
      * Transforms an XML string to an element.
      *
-     * @param string $string
-     *
      * @throws \RuntimeException
-     *
-     * @return \SimpleXMLElement
      */
     public static function xmlToElement(string $string): \SimpleXMLElement
     {
@@ -50,11 +46,7 @@ final class StringUtil
     /**
      * Transforms a JSON string to an array.
      *
-     * @param string $string
-     *
      * @throws \RuntimeException
-     *
-     * @return array
      */
     public static function jsonToArray(string $string): array
     {

--- a/src/StringUtil.php
+++ b/src/StringUtil.php
@@ -31,17 +31,14 @@ final class StringUtil
      */
     public static function xmlToElement(string $string): \SimpleXMLElement
     {
-        $disableEntities = libxml_disable_entity_loader(true);
         $internalErrors = libxml_use_internal_errors(true);
 
         try {
             // Allow XML to be retrieved even if there is no response body
             $xml = new \SimpleXMLElement($string ?: '<root />', LIBXML_NONET);
 
-            libxml_disable_entity_loader($disableEntities);
             libxml_use_internal_errors($internalErrors);
         } catch (\Exception $e) {
-            libxml_disable_entity_loader($disableEntities);
             libxml_use_internal_errors($internalErrors);
 
             throw new \RuntimeException('Unable to parse XML data: '.$e->getMessage());

--- a/tests/Tests/CurrencyPairTest.php
+++ b/tests/Tests/CurrencyPairTest.php
@@ -42,10 +42,10 @@ class CurrencyPairTest extends TestCase
     /**
      * @test
      * @dataProvider invalidStringProvider
-     * @expectedException \InvalidArgumentException
      */
     public function it_throws_an_exception_when_creating_from_an_invalid_string($string)
     {
+        $this->expectException(\InvalidArgumentException::class);
         CurrencyPair::createFromString($string);
     }
 

--- a/tests/Tests/Exception/ChainExceptionTest.php
+++ b/tests/Tests/Exception/ChainExceptionTest.php
@@ -36,7 +36,7 @@ class ChainExceptionTest extends TestCase
      */
     private $exception2;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->exception1 = new \Exception('Something bad happened.');
         $this->exception2 = new \Exception('General exception.');

--- a/tests/Tests/ExchangerTest.php
+++ b/tests/Tests/ExchangerTest.php
@@ -16,6 +16,8 @@ namespace Exchanger\Tests;
 use Exchanger\ExchangeRate;
 use Exchanger\ExchangeRateQuery;
 use Exchanger\CurrencyPair;
+use Exchanger\Exception\CacheException;
+use Exchanger\Exception\UnsupportedExchangeQueryException;
 use Exchanger\Exchanger;
 use PHPUnit\Framework\TestCase;
 
@@ -23,10 +25,10 @@ class ExchangerTest extends TestCase
 {
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedExchangeQueryException
      */
     public function it_throws_an_exception_when_service_does_not_support_query()
     {
+        $this->expectException(UnsupportedExchangeQueryException::class);
         $service = $this->createMock('Exchanger\Contract\ExchangeRateService');
 
         $service
@@ -268,10 +270,10 @@ class ExchangerTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\CacheException
      */
     public function it_throws_an_exception_if_cache_key_is_too_long()
     {
+        $this->expectException(CacheException::class);
         $exchangeRateQuery = new ExchangeRateQuery(CurrencyPair::createFromString('EUR/USD'));
 
         $service = $this->createMock('Exchanger\Contract\ExchangeRateService');
@@ -289,10 +291,10 @@ class ExchangerTest extends TestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedExchangeQueryException
      */
     public function it_throws_an_exception_if_service_cant_support_pair()
     {
+        $this->expectException(UnsupportedExchangeQueryException::class);
         $exchangeRateQuery = new ExchangeRateQuery(CurrencyPair::createFromString('EUR/USD'));
 
         $service = $this->createMock('Exchanger\Contract\ExchangeRateService');

--- a/tests/Tests/Integration/ExchangerTest.php
+++ b/tests/Tests/Integration/ExchangerTest.php
@@ -27,7 +27,7 @@ class ExchangerTest extends TestCase
 {
     private $fixerAccessKey;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->fixerAccessKey = getenv('FIXER_ACCESS_KEY');
     }

--- a/tests/Tests/Service/BulgarianNationalBankTest.php
+++ b/tests/Tests/Service/BulgarianNationalBankTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Exchanger\Tests\Service;
 
 use Exchanger\CurrencyPair;
+use Exchanger\Exception\UnsupportedCurrencyPairException;
+use Exchanger\Exception\UnsupportedDateException;
 use Exchanger\ExchangeRateQuery;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\Service\BulgarianNationalBank;
@@ -27,7 +29,7 @@ class BulgarianNationalBankTest extends ServiceTestCase
 
     protected static $historicalUrl;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$url = sprintf(BulgarianNationalBank::URL, date('d'), date('m'), date('Y'));
         self::$historicalUrl = sprintf(BulgarianNationalBank::URL, '01', '02', '2019');
@@ -115,10 +117,10 @@ class BulgarianNationalBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedDateException
      */
     public function it_throws_an_exception_when_it_cannot_retrieve_an_xml_document_for_the_requested_date()
     {
+        $this->expectException(UnsupportedDateException::class);
         $expectedExceptionMessage = 'The date "%s" is not supported by the service "Exchanger\Service\BulgarianNationalBank".';
         $this->expectExceptionMessage(sprintf($expectedExceptionMessage, date('Y-m-d')));
 
@@ -131,11 +133,13 @@ class BulgarianNationalBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedDateException
-     * @expectedExceptionMessage The date "2019-02-01" is not supported by the service "Exchanger\Service\BulgarianNationalBank".
      */
     public function it_throws_an_exception_when_it_cannot_retrieve_an_xml_document_for_the_requested_date_historical()
     {
+        $this->expectException(UnsupportedDateException::class);
+        $expectedExceptionMessage = 'The date "2019-02-01" is not supported by the service "Exchanger\Service\BulgarianNationalBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $pair = CurrencyPair::createFromString('EUR/BGN');
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/BulgarianNationalBank/failure.html');
 
@@ -145,11 +149,13 @@ class BulgarianNationalBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "ABC/BGN" is not supported by the service "Exchanger\Service\BulgarianNationalBank".
      */
     public function it_throws_an_exception_when_the_pair_is_not_supported()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "ABC/BGN" is not supported by the service "Exchanger\Service\BulgarianNationalBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $pair = CurrencyPair::createFromString('ABC/BGN');
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/BulgarianNationalBank/success.xml');
 
@@ -159,11 +165,13 @@ class BulgarianNationalBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "ABC/BGN" is not supported by the service "Exchanger\Service\BulgarianNationalBank".
      */
     public function it_throws_an_exception_when_the_pair_is_not_supported_historical()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "ABC/BGN" is not supported by the service "Exchanger\Service\BulgarianNationalBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $pair = CurrencyPair::createFromString('ABC/BGN');
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/BulgarianNationalBank/success.xml');
 
@@ -175,10 +183,10 @@ class BulgarianNationalBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedDateException
      */
     public function it_throws_an_exception_when_the_date_field_for_the_pair_cannot_be_detected()
     {
+        $this->expectException(UnsupportedDateException::class);
         $expectedExceptionMessage = 'The date "%s" is not supported by the service "Exchanger\Service\BulgarianNationalBank".';
         $this->expectExceptionMessage(sprintf($expectedExceptionMessage, date('Y-m-d')));
 
@@ -191,11 +199,13 @@ class BulgarianNationalBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedDateException
-     * @expectedExceptionMessage The date "2019-02-01" is not supported by the service "Exchanger\Service\BulgarianNationalBank".
      */
     public function it_throws_an_exception_when_the_date_field_for_the_pair_cannot_be_detected_historical()
     {
+        $this->expectException(UnsupportedDateException::class);
+        $expectedExceptionMessage = 'The date "2019-02-01" is not supported by the service "Exchanger\Service\BulgarianNationalBank".';
+        $this->expectExceptionMessage(sprintf($expectedExceptionMessage, date('Y-m-d')));
+
         $pair = CurrencyPair::createFromString('AUD/BGN');
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/BulgarianNationalBank/missingfields.xml');
 
@@ -207,11 +217,13 @@ class BulgarianNationalBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "CAD/BGN" is not supported by the service "Exchanger\Service\BulgarianNationalBank".
      */
     public function it_throws_an_exception_when_the_ratio_field_for_the_pair_cannot_be_detected()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "CAD/BGN" is not supported by the service "Exchanger\Service\BulgarianNationalBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $pair = CurrencyPair::createFromString('CAD/BGN');
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/BulgarianNationalBank/missingfields.xml');
 
@@ -221,11 +233,13 @@ class BulgarianNationalBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "CAD/BGN" is not supported by the service "Exchanger\Service\BulgarianNationalBank".
      */
     public function it_throws_an_exception_when_the_ratio_field_for_the_pair_cannot_be_detected_historical()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "CAD/BGN" is not supported by the service "Exchanger\Service\BulgarianNationalBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $pair = CurrencyPair::createFromString('CAD/BGN');
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/BulgarianNationalBank/missingfields.xml');
 
@@ -237,11 +251,13 @@ class BulgarianNationalBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "USD/BGN" is not supported by the service "Exchanger\Service\BulgarianNationalBank".
      */
     public function it_throws_an_exception_when_the_rate_field_for_the_pair_cannot_be_detected()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "USD/BGN" is not supported by the service "Exchanger\Service\BulgarianNationalBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $pair = CurrencyPair::createFromString('USD/BGN');
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/BulgarianNationalBank/missingfields.xml');
 
@@ -251,11 +267,13 @@ class BulgarianNationalBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "USD/BGN" is not supported by the service "Exchanger\Service\BulgarianNationalBank".
      */
     public function it_throws_an_exception_when_the_rate_field_for_the_pair_cannot_be_detected_historical()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "USD/BGN" is not supported by the service "Exchanger\Service\BulgarianNationalBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $pair = CurrencyPair::createFromString('USD/BGN');
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/BulgarianNationalBank/missingfields.xml');
 

--- a/tests/Tests/Service/CentralBankOfCzechRepublicTest.php
+++ b/tests/Tests/Service/CentralBankOfCzechRepublicTest.php
@@ -46,7 +46,7 @@ class CentralBankOfCzechRepublicTest extends ServiceTestCase
     /**
      * Set up variables before TestCase is being initialized.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$url = 'https://www.cnb.cz/cs/financni-trhy/devizovy-trh/kurzy-devizoveho-trhu/kurzy-devizoveho-trhu/denni_kurz.txt?date='.date('d.m.Y');
         self::$historicalUrl = 'https://www.cnb.cz/cs/financni-trhy/devizovy-trh/kurzy-devizoveho-trhu/kurzy-devizoveho-trhu/denni_kurz.txt?date=23.04.2000';
@@ -57,7 +57,7 @@ class CentralBankOfCzechRepublicTest extends ServiceTestCase
     /**
      * Clean variables after TestCase finish.
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$url = null;
         self::$content = null;

--- a/tests/Tests/Service/CentralBankOfRepublicTurkeyTest.php
+++ b/tests/Tests/Service/CentralBankOfRepublicTurkeyTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Exchanger\Tests\Service;
 
+use Exchanger\Exception\UnsupportedCurrencyPairException;
 use Exchanger\ExchangeRateQuery;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\CurrencyPair;
@@ -43,7 +44,7 @@ class CentralBankOfRepublicTurkeyTest extends ServiceTestCase
     /**
      * Set up variables before TestCase is being initialized.
      */
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$url = 'https://www.tcmb.gov.tr/kurlar/today.xml';
         self::$historicalUrl = 'https://www.tcmb.gov.tr/kurlar/201304/23042013.xml';
@@ -54,7 +55,7 @@ class CentralBankOfRepublicTurkeyTest extends ServiceTestCase
     /**
      * Clean variables after TestCase finish.
      */
-    public static function tearDownAfterClass()
+    public static function tearDownAfterClass(): void
     {
         self::$url = null;
         self::$content = null;
@@ -93,10 +94,10 @@ class CentralBankOfRepublicTurkeyTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
      */
     public function it_throws_an_exception_when_the_pair_is_not_supported()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
         $url = 'https://www.tcmb.gov.tr/kurlar/today.xml';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/CentralBankOfRepublicTurkey/cbrt_today.xml');
 

--- a/tests/Tests/Service/CoinLayerTest.php
+++ b/tests/Tests/Service/CoinLayerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Exchanger\Tests\Service;
 
+use Exchanger\Exception\Exception;
 use Exchanger\ExchangeRateQuery;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\CurrencyPair;
@@ -25,11 +26,11 @@ class CoinLayerTest extends ServiceTestCase
 {
     /**
      * @test
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The "access_key" option must be provided.
      */
     public function it_throws_an_exception_if_access_key_option_missing()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "access_key" option must be provided.');
         new CoinLayer($this->createMock('Http\Client\HttpClient'));
     }
 
@@ -44,10 +45,10 @@ class CoinLayerTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\Exception
      */
     public function it_throws_an_exception_with_error_response()
     {
+        $this->expectException(Exception::class);
         $uri = 'http://api.coinlayer.com/api/live?access_key=secret&symbols=BTC&target=USD';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/CoinLayer/error.json');
 

--- a/tests/Tests/Service/CryptonatorTest.php
+++ b/tests/Tests/Service/CryptonatorTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Exchanger\Tests\Service;
 
+use Exchanger\Exception\Exception;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\CurrencyPair;
 use Exchanger\ExchangeRateQuery;
@@ -43,10 +44,10 @@ class CryptonatorTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\Exception
      */
     public function it_throws_an_exception_when_rate_not_supported()
     {
+        $this->expectException(Exception::class);
         $uri = 'https://api.cryptonator.com/api/ticker/btc-isk';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/Cryptonator/error.json');
 

--- a/tests/Tests/Service/CurrencyConverterTest.php
+++ b/tests/Tests/Service/CurrencyConverterTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Exchanger\Tests\Service;
 
 use Exchanger\CurrencyPair;
+use Exchanger\Exception\Exception;
 use Exchanger\ExchangeRateQuery;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\Service\CurrencyConverter;
@@ -26,20 +27,20 @@ class CurrencyConverterTest extends TestCase
 {
     /**
      * @test
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The "access_key" option must be provided.
      */
     public function it_throws_an_exception_if_access_key_option_missing_in_enterprise_mode()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "access_key" option must be provided.');
         new CurrencyConverter($this->createMock(HttpClient::class), null, ['enterprise' => true]);
     }
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\Exception
      */
     public function it_throws_an_exception_with_error_response()
     {
+        $this->expectException(Exception::class);
         $uri = 'https://free.currencyconverterapi.com/api/v6/convert?q=XXX_YYY&date=2000-01-01';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/CurrencyConverter/error.json');
 

--- a/tests/Tests/Service/CurrencyDataFeedTest.php
+++ b/tests/Tests/Service/CurrencyDataFeedTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Exchanger\Tests\Service;
 
+use Exchanger\Exception\Exception;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\CurrencyPair;
 use Exchanger\ExchangeRateQuery;
@@ -33,10 +34,10 @@ class CurrencyDataFeedTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\Exception
      */
     public function it_throws_an_exception_when_rate_not_supported()
     {
+        $this->expectException(Exception::class);
         $url = 'https://currencydatafeed.com/api/data.php?token=secret&currency=EUR/ZZZ';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/CurrencyDataFeed/error.json');
         $service = new CurrencyDataFeed($this->getHttpAdapterMock($url, $content), null, ['api_key' => 'secret']);

--- a/tests/Tests/Service/CurrencyLayerTest.php
+++ b/tests/Tests/Service/CurrencyLayerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Exchanger\Tests\Service;
 
+use Exchanger\Exception\Exception;
 use Exchanger\ExchangeRateQuery;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\CurrencyPair;
@@ -25,11 +26,11 @@ class CurrencyLayerTest extends ServiceTestCase
 {
     /**
      * @test
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The "access_key" option must be provided.
      */
     public function it_throws_an_exception_if_access_key_option_missing()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "access_key" option must be provided.');
         new CurrencyLayer($this->createMock('Http\Client\HttpClient'));
     }
 
@@ -44,10 +45,10 @@ class CurrencyLayerTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\Exception
      */
     public function it_throws_an_exception_with_error_response()
     {
+        $this->expectException(Exception::class);
         $uri = 'http://www.apilayer.net/api/live?access_key=secret&currencies=EUR';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/CurrencyLayer/error.json');
 

--- a/tests/Tests/Service/EuropeanCentralBankTest.php
+++ b/tests/Tests/Service/EuropeanCentralBankTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Exchanger\Tests\Service;
 
+use Exchanger\Exception\UnsupportedCurrencyPairException;
+use Exchanger\Exception\UnsupportedDateException;
 use Exchanger\ExchangeRateQuery;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\CurrencyPair;
@@ -32,11 +34,13 @@ class EuropeanCentralBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "EUR/XXL" is not supported by the service "Exchanger\Service\EuropeanCentralBank".
      */
     public function it_throws_an_exception_when_the_pair_is_not_supported()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "EUR/XXL" is not supported by the service "Exchanger\Service\EuropeanCentralBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $url = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/EuropeanCentralBank/success.xml');
 
@@ -106,11 +110,13 @@ class EuropeanCentralBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedDateException
-     * @expectedExceptionMessage The date "2016-05-26" is not supported by the service "Exchanger\Service\EuropeanCentralBank".
      */
     public function it_throws_an_exception_when_historical_date_is_not_supported()
     {
+        $this->expectException(UnsupportedDateException::class);
+        $expectedExceptionMessage = 'The date "2016-05-26" is not supported by the service "Exchanger\Service\EuropeanCentralBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $url = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/EuropeanCentralBank/historical.xml');
 
@@ -120,11 +126,13 @@ class EuropeanCentralBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "EUR/XXL" is not supported by the service "Exchanger\Service\EuropeanCentralBank".
      */
     public function it_throws_an_exception_when_the_pair_is_not_supported_historical()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "EUR/XXL" is not supported by the service "Exchanger\Service\EuropeanCentralBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $url = 'https://www.ecb.europa.eu/stats/eurofxref/eurofxref-hist.xml';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/EuropeanCentralBank/historical.xml');
 

--- a/tests/Tests/Service/ExchangeRatesApiTest.php
+++ b/tests/Tests/Service/ExchangeRatesApiTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Exchanger\Tests\Service;
 
 use Exchanger\CurrencyPair;
+use Exchanger\Exception\Exception;
 use Exchanger\ExchangeRateQuery;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\Service\ExchangeRatesApi;
@@ -53,11 +54,12 @@ class ExchangeRatesApiTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\Exception
-     * @expectedExceptionMessage Base 'FOO' is not supported.
      */
     public function it_throws_an_exception_with_error_response()
     {
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Base \'FOO\' is not supported.');
+
         $uri = 'https://api.exchangeratesapi.io/latest?base=FOO';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/ExchangeRatesApi/error.json');
 

--- a/tests/Tests/Service/FixerTest.php
+++ b/tests/Tests/Service/FixerTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Exchanger\Tests\Service;
 
+use Exchanger\Exception\Exception;
 use Exchanger\ExchangeRateQuery;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\CurrencyPair;
@@ -52,11 +53,13 @@ class FixerTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\Exception
-     * @expectedExceptionMessage The current subscription plan does not support this API endpoint.
      */
     public function it_throws_an_exception_with_error_response()
     {
+        $this->expectException(Exception::class);
+        $expectedExceptionMessage = 'The current subscription plan does not support this API endpoint.';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $uri = 'http://data.fixer.io/api/latest?access_key=x';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/Fixer/error.json');
 

--- a/tests/Tests/Service/ForgeTest.php
+++ b/tests/Tests/Service/ForgeTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Exchanger\Tests\Service;
 
+use Exchanger\Exception\Exception;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\CurrencyPair;
 use Exchanger\ExchangeRateQuery;
@@ -33,10 +34,10 @@ class ForgeTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\Exception
      */
     public function it_throws_an_exception_when_rate_not_supported()
     {
+        $this->expectException(Exception::class);
         $url = 'https://api.1forge.com/quotes?pairs=EUR/ZZZ&api_key=secret';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/Forge/error.json');
         $service = new Forge($this->getHttpAdapterMock($url, $content), null, ['api_key' => 'secret']);
@@ -81,10 +82,10 @@ class ForgeTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\Exception
      */
     public function it_throws_an_exception_when_response_symbol_does_not_match()
     {
+        $this->expectException(Exception::class);
         $url = 'https://api.1forge.com/quotes?pairs=USD/AED&api_key=secret';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/Forge/multiple.json');
         $service = new Forge($this->getHttpAdapterMock($url, $content), null, ['api_key' => 'secret']);

--- a/tests/Tests/Service/NationalBankOfUkraineTest.php
+++ b/tests/Tests/Service/NationalBankOfUkraineTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Exchanger\Tests\Service;
 
+use Exchanger\Exception\UnsupportedCurrencyPairException;
+use Exchanger\Exception\UnsupportedDateException;
 use Exchanger\ExchangeRateQuery;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\CurrencyPair;
@@ -39,11 +41,13 @@ class NationalBankOfUkraineTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "XXL/UAH" is not supported by the service "Exchanger\Service\NationalBankOfUkraine".
      */
     public function it_throws_an_exception_when_the_pair_is_not_supported()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "XXL/UAH" is not supported by the service "Exchanger\Service\NationalBankOfUkraine".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $url = 'https://bank.gov.ua/NBUStatService/v1/statdirectory/exchange';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/NationalBankOfUkraine/success.xml');
 
@@ -109,11 +113,13 @@ class NationalBankOfUkraineTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedDateException
-     * @expectedExceptionMessage The date "1990-01-01" is not supported by the service "Exchanger\Service\NationalBankOfUkraine".
      */
     public function it_throws_an_exception_when_historical_date_is_not_supported()
     {
+        $this->expectException(UnsupportedDateException::class);
+        $expectedExceptionMessage = 'The date "1990-01-01" is not supported by the service "Exchanger\Service\NationalBankOfUkraine".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $url = 'https://bank.gov.ua/NBUStatService/v1/statdirectory/exchange?date=19900101';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/NationalBankOfUkraine/historical_error.xml');
 
@@ -123,11 +129,13 @@ class NationalBankOfUkraineTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "XXL/UAH" is not supported by the service "Exchanger\Service\NationalBankOfUkraine".
      */
     public function it_throws_an_exception_when_the_pair_is_not_supported_historical()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "XXL/UAH" is not supported by the service "Exchanger\Service\NationalBankOfUkraine".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $url = 'https://bank.gov.ua/NBUStatService/v1/statdirectory/exchange?date=20190101';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/NationalBankOfUkraine/historical.xml');
 

--- a/tests/Tests/Service/OpenExchangeRatesTest.php
+++ b/tests/Tests/Service/OpenExchangeRatesTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Exchanger\Tests\Service;
 
+use Exchanger\Exception\Exception;
+use Exchanger\Exception\UnsupportedCurrencyPairException;
 use Exchanger\ExchangeRateQuery;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\CurrencyPair;
@@ -22,11 +24,11 @@ class OpenExchangeRatesTest extends ServiceTestCase
 {
     /**
      * @test
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The "app_id" option must be provided.
      */
     public function it_throws_an_exception_if_app_id_option_missing()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "app_id" option must be provided.');
         new OpenExchangeRates($this->createMock('Http\Client\HttpClient'));
     }
 
@@ -43,10 +45,10 @@ class OpenExchangeRatesTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\Exception
      */
     public function it_throws_an_exception_with_error_response()
     {
+        $this->expectException(Exception::class);
         $uri = 'https://openexchangerates.org/api/latest.json?app_id=secret&show_alternative=1';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/OpenExchangeRates/error.json');
 
@@ -142,11 +144,13 @@ class OpenExchangeRatesTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\Exception
-     * @expectedExceptionMessage Historical rates for the requested date are not available - please try a different date, or contact support@openexchangerates.org.
      */
     public function it_throws_an_exception_when_historical_date_is_not_supported()
     {
+        $this->expectException(Exception::class);
+        $expectedExceptionMessage = 'Historical rates for the requested date are not available - please try a different date, or contact support@openexchangerates.org.';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $url = 'https://openexchangerates.org/api/historical/1900-08-23.json?app_id=secret&show_alternative=1';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/OpenExchangeRates/historical_error.json');
 
@@ -159,11 +163,13 @@ class OpenExchangeRatesTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "USD/XXL" is not supported by the service "Exchanger\Service\OpenExchangeRates".
      */
     public function it_throws_an_exception_when_the_pair_is_not_supported_historical()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "USD/XXL" is not supported by the service "Exchanger\Service\OpenExchangeRates".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $url = 'https://openexchangerates.org/api/historical/2016-08-23.json?app_id=secret&show_alternative=1';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/OpenExchangeRates/historical_success.json');
 

--- a/tests/Tests/Service/PhpArrayTest.php
+++ b/tests/Tests/Service/PhpArrayTest.php
@@ -59,11 +59,12 @@ class PhpArrayTest extends TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Rates passed to the PhpArray service must be scalars, "array" given.
      */
     public function it_throws_an_exception_when_fetching_latest_invalid_rate()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Rates passed to the PhpArray service must be scalars, "array" given.');
+
         $arrayProvider = new PhpArray([
             'EUR/USD' => [],
         ]);
@@ -120,11 +121,13 @@ class PhpArrayTest extends TestCase
 
     /**
      * @test
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Rates passed to the PhpArray service must be scalars, "array" given.
      */
     public function it_throws_an_exception_when_fetching_historical_invalid_rate()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $expectedExceptionMessage = 'Rates passed to the PhpArray service must be scalars, "array" given.';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $now = new \DateTimeImmutable();
 
         $arrayProvider = new PhpArray([], [

--- a/tests/Tests/Service/RussianCentralBankTest.php
+++ b/tests/Tests/Service/RussianCentralBankTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Exchanger\Tests\Service;
 
+use Exchanger\Exception\UnsupportedCurrencyPairException;
+use Exchanger\Exception\UnsupportedDateException;
 use Exchanger\ExchangeRateQuery;
 use Exchanger\HistoricalExchangeRateQuery;
 use Exchanger\CurrencyPair;
@@ -34,11 +36,13 @@ class RussianCentralBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "XXL/RUB" is not supported by the service "Exchanger\Service\RussianCentralBank".
      */
     public function it_throws_an_exception_when_the_pair_is_not_supported()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "XXL/RUB" is not supported by the service "Exchanger\Service\RussianCentralBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $url = 'http://www.cbr.ru/scripts/XML_daily.asp';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/RussianCentralBank/success.xml');
 
@@ -104,11 +108,13 @@ class RussianCentralBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedDateException
-     * @expectedExceptionMessage The date "1986-08-23" is not supported by the service "Exchanger\Service\RussianCentralBank".
      */
     public function it_throws_an_exception_when_historical_date_is_not_supported()
     {
+        $this->expectException(UnsupportedDateException::class);
+        $expectedExceptionMessage = 'The date "1986-08-23" is not supported by the service "Exchanger\Service\RussianCentralBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $url = 'http://www.cbr.ru/scripts/XML_daily.asp?date_req=23.08.1986';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/RussianCentralBank/historical_error.xml');
 
@@ -118,11 +124,13 @@ class RussianCentralBankTest extends ServiceTestCase
 
     /**
      * @test
-     * @expectedException \Exchanger\Exception\UnsupportedCurrencyPairException
-     * @expectedExceptionMessage The currency pair "XXL/RUB" is not supported by the service "Exchanger\Service\RussianCentralBank".
      */
     public function it_throws_an_exception_when_the_pair_is_not_supported_historical()
     {
+        $this->expectException(UnsupportedCurrencyPairException::class);
+        $expectedExceptionMessage = 'The currency pair "XXL/RUB" is not supported by the service "Exchanger\Service\RussianCentralBank".';
+        $this->expectExceptionMessage($expectedExceptionMessage);
+
         $url = 'http://www.cbr.ru/scripts/XML_daily.asp?date_req=23.08.2016';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/RussianCentralBank/historical.xml');
 

--- a/tests/Tests/Service/XigniteTest.php
+++ b/tests/Tests/Service/XigniteTest.php
@@ -23,11 +23,11 @@ class XigniteTest extends ServiceTestCase
 {
     /**
      * @test
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The "token" option must be provided.
      */
     public function it_throws_an_exception_if_token_option_missing()
     {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('The "token" option must be provided.');
         new Xignite($this->createMock('Http\Client\HttpClient'));
     }
 

--- a/tests/Tests/StringUtilTest.php
+++ b/tests/Tests/StringUtilTest.php
@@ -31,10 +31,10 @@ class StringUtilTest extends TestCase
 
     /**
      * @test
-     * @expectedException \RuntimeException
      */
     public function it_throws_an_exception_when_converting_invalid_xml()
     {
+        $this->expectException(\RuntimeException::class);
         StringUtil::xmlToElement('/');
     }
 
@@ -49,10 +49,10 @@ class StringUtilTest extends TestCase
 
     /**
      * @test
-     * @expectedException \RuntimeException
      */
     public function it_throws_an_exception_when_converting_invalid_json()
     {
+        $this->expectException(\RuntimeException::class);
         StringUtil::jsonToArray('/');
     }
 }


### PR DESCRIPTION
* Removed a deprecated call to `libxml_disable_entity_loader()`.
* Upgraded to PHPUnit 9.4; used `$this->expectException()` instead of annotations, fixed inherited method declarations.

Tested with PHP versions: 7.1.33, 7.2.34, 7.3.24, 7.4.12, 8.0.0RC5.

Fixes #124 