### PR TITLE
Add new query parameter “places” and “soruce” to exchangerate.host service

### DIFF
--- a/src/Service/ExchangerateHost.php
+++ b/src/Service/ExchangerateHost.php
@@ -34,6 +34,8 @@ final class ExchangerateHost extends HttpService
     const LATEST_URL = 'https://api.exchangerate.host/latest?base=%s&v=%s';
 
     const HISTORICAL_URL = 'https://api.exchangerate.host/%s?base=%s';
+    const OPTION_PLACES = 'places';
+    const OPTION_SOURCE = 'source';
 
     /**
      * {@inheritdoc}
@@ -48,7 +50,7 @@ final class ExchangerateHost extends HttpService
             date('Y-m-d')
 		);
 
-        return $this->doCreateRate($url, $currencyPair);
+        return $this->doCreateRate($this->additionalQueryParameters($url, $exchangeQuery), $currencyPair);
     }
 
     /**
@@ -64,7 +66,7 @@ final class ExchangerateHost extends HttpService
 			$exchangeQuery->getCurrencyPair()->getBaseCurrency()
 		);
 
-        return $this->doCreateRate($url, $currencyPair);
+        return $this->doCreateRate($this->additionalQueryParameters($url, $exchangeQuery), $currencyPair);
     }
 
     /**
@@ -110,5 +112,34 @@ final class ExchangerateHost extends HttpService
     public function getName(): string
     {
         return 'exchangeratehost';
+    }
+
+    private function additionalQueryParameters(string $url, $exchangeRateQuery): string
+    {
+        if (isset($this->options[self::OPTION_PLACES])) {
+            $places = $this->options[self::OPTION_PLACES];
+        }
+
+        if ($exchangeRateQuery->getOption(self::OPTION_PLACES)) {
+            $places = $exchangeRateQuery->getOption(self::OPTION_PLACES);
+        }
+
+        if (isset($this->options[self::OPTION_SOURCE])) {
+            $source = $this->options[self::OPTION_SOURCE];
+        }
+
+        if ($exchangeRateQuery->getOption(self::OPTION_SOURCE)) {
+            $source = $exchangeRateQuery->getOption(self::OPTION_SOURCE);
+        }
+
+        if (isset($places)) {
+            $url .= '&places=' . $places;
+        }
+
+        if (isset($source)) {
+            $url .= '&source='. $source;
+        }
+
+        return $url;
     }
 }

--- a/tests/Tests/Service/ExchangerateHostTest.php
+++ b/tests/Tests/Service/ExchangerateHostTest.php
@@ -89,6 +89,86 @@ class ExchangerateHostTest extends ServiceTestCase
     /**
      * @test
      */
+    public function it_fetches_uses_a_specific_source_option()
+    {
+        $pair = CurrencyPair::createFromString('EUR/AUD');
+        $uri = 'https://api.exchangerate.host/2000-01-03?base=EUR&source=ecb';
+        $content = file_get_contents(__DIR__.'/../../Fixtures/Service/ExchangerateHost/historical.json');
+        $date = new \DateTime('2000-01-03');
+
+        $service = new ExchangerateHost($this->getHttpAdapterMock($uri, $content), null, ['source' => 'ecb']);
+
+        $rate = $service->getExchangeRate(new HistoricalExchangeRateQuery($pair, $date));
+
+        $this->assertEquals(1.5346, $rate->getValue());
+        $this->assertEquals($date, $rate->getDate());
+        $this->assertEquals('exchangeratehost', $rate->getProviderName());
+        $this->assertSame($pair, $rate->getCurrencyPair());
+    }
+
+    /**
+     * @test
+     */
+    public function it_fetches_uses_a_specific_source_option_overridden_by_exchange_query_method()
+    {
+        $pair = CurrencyPair::createFromString('EUR/AUD');
+        $uri = 'https://api.exchangerate.host/2000-01-03?base=EUR&source=testing';
+        $content = file_get_contents(__DIR__.'/../../Fixtures/Service/ExchangerateHost/historical.json');
+        $date = new \DateTime('2000-01-03');
+
+        $service = new ExchangerateHost($this->getHttpAdapterMock($uri, $content), null, ['source' => 'ecb']);
+
+        $rate = $service->getExchangeRate(new HistoricalExchangeRateQuery($pair, $date, ['source' => 'testing']));
+
+        $this->assertEquals(1.5346, $rate->getValue());
+        $this->assertEquals($date, $rate->getDate());
+        $this->assertEquals('exchangeratehost', $rate->getProviderName());
+        $this->assertSame($pair, $rate->getCurrencyPair());
+    }
+
+    /**
+     * @test
+     */
+    public function it_fetches_uses_a_specific_places_option_overridden_by_exchange_query_method()
+    {
+        $pair = CurrencyPair::createFromString('EUR/AUD');
+        $uri = 'https://api.exchangerate.host/2000-01-03?base=EUR&places=10';
+        $content = file_get_contents(__DIR__.'/../../Fixtures/Service/ExchangerateHost/historical.json');
+        $date = new \DateTime('2000-01-03');
+
+        $service = new ExchangerateHost($this->getHttpAdapterMock($uri, $content), null, ['places' => 6]);
+
+        $rate = $service->getExchangeRate(new HistoricalExchangeRateQuery($pair, $date, ['places' => 10]));
+
+        $this->assertEquals(1.5346, $rate->getValue());
+        $this->assertEquals($date, $rate->getDate());
+        $this->assertEquals('exchangeratehost', $rate->getProviderName());
+        $this->assertSame($pair, $rate->getCurrencyPair());
+    }
+
+    /**
+     * @test
+     */
+    public function it_fetches_uses_a_specific_places_option()
+    {
+        $pair = CurrencyPair::createFromString('EUR/AUD');
+        $uri = 'https://api.exchangerate.host/2000-01-03?base=EUR&places=6';
+        $content = file_get_contents(__DIR__.'/../../Fixtures/Service/ExchangerateHost/historical.json');
+        $date = new \DateTime('2000-01-03');
+
+        $service = new ExchangerateHost($this->getHttpAdapterMock($uri, $content), null, ['places' => 6]);
+
+        $rate = $service->getExchangeRate(new HistoricalExchangeRateQuery($pair, $date));
+
+        $this->assertEquals(1.5346, $rate->getValue());
+        $this->assertEquals($date, $rate->getDate());
+        $this->assertEquals('exchangeratehost', $rate->getProviderName());
+        $this->assertSame($pair, $rate->getCurrencyPair());
+    }
+
+    /**
+     * @test
+     */
     public function it_has_a_name()
     {
         $service = new ExchangerateHost($this->createMock('Http\Client\HttpClient'));


### PR DESCRIPTION
Hello everybody.

First of i love this package but it's lacking some features for a specific service exchangerate.host.

The new `places` option determines the number of decimals that one want the api to return.

Secondly the `source` option allows somebody to be explicit about which data-source the service should use to lookup the currency rate. 