### PR TITLE
fix currency layer datetime

### DIFF
--- a/src/Service/CurrencyLayer.php
+++ b/src/Service/CurrencyLayer.php
@@ -129,7 +129,12 @@ final class CurrencyLayer extends HttpService
             throw new Exception($data['error']['info']);
         }
 
-        $date = new \DateTime($data['date']);
+        if (isset($data['date'])) {
+            $date = new \DateTime($data['date']);
+        } else {
+            $date = (new \DateTime())->setTimestamp($data['timestamp']);
+        }
+        
         $hash = $currencyPair->getBaseCurrency().$currencyPair->getQuoteCurrency();
 
         if ($data['source'] === $currencyPair->getBaseCurrency() && isset($data['quotes'][$hash])) {

--- a/src/Service/CurrencyLayer.php
+++ b/src/Service/CurrencyLayer.php
@@ -129,7 +129,7 @@ final class CurrencyLayer extends HttpService
             throw new Exception($data['error']['info']);
         }
 
-        $date = (new \DateTime())->setTimestamp($data['timestamp']);
+        $date = new \DateTime($data['date']);
         $hash = $currencyPair->getBaseCurrency().$currencyPair->getQuoteCurrency();
 
         if ($data['source'] === $currencyPair->getBaseCurrency() && isset($data['quotes'][$hash])) {


### PR DESCRIPTION
Dear author, 

The origin currency_layer service uses `$data['timestamp']` from the response as a basis for setting the date for the exchange rate. I found that it's actually a day later than the `date` parameter queried in the URI. 

Here is an example:

```shell
https://apilayer.net/api/historical?access_key={enterprise_key}&date=2023-07-18&source=CNY

{
  "success": true,
  "terms": "https:\\/\\/currencylayer.com\\/terms",
  "privacy": "https:\\/\\/currencylayer.com\\/privacy",
  "historical": true,
  "date": "2023-07-18",
  "timestamp": 1689724799, <-- it's 2023-07-19
  "source": "CNY",
  "quotes": {
    "CNYAED": 0.511535,
    "CNYAFN": 12.186502,
    "CNYALL": 12.704895,
    "CNYAMD": 54.401628,
    "CNYANG": 0.251082,
    "CNYAOA": 115.10576,
    "CNYARS": 37.257068,
    "CNYAUD": 0.204374,
    "CNYAWG": 0.250686,
    "CNYAZN": 0.237015,
    "CNYBAM": 0.242035,
    "CNYBBD": 0.281287,
    "CNYBDT": 15.120089,
    "CNYBGN": 0.242545,
    "CNYBHD": 0.052486,
    "CNYBIF": 394.185547,
    "CNYBMD": 0.13927,
    "CNYBND": 0.18404,
    "CNYBOB": 0.962671,
    "CNYBRL": 0.67,
    "CNYBSD": 0.139307,
    "CNYBTC": 0.000004664155,
    "CNYBTN": 11.429032,
    "CNYBWP": 1.829402,
    "CNYBYN": 0.351634,
    "CNYBYR": 2729.690053,
    "CNYBZD": 0.280817,
    "CNYCAD": 0.183373,
    "CNYCDF": 336.336787,
    "CNYCHF": 0.119455,
    "CNYCLF": 0.004118,
    "CNYCLP": 113.623348,
    "CNYCOP": 557.814948,
    "CNYCRC": 74.920469,
    "CNYCUC": 0.13927,
    "CNYCUP": 3.690652,
    "CNYCVE": 13.644897,
    "CNYCZK": 2.958664,
    "CNYDJF": 24.751012,
    "CNYDKK": 0.924139,
    "CNYDOP": 7.792162,
    "CNYDZD": 18.71025,
    "CNYEGP": 4.302799,
    "CNYERN": 2.089049,
    "CNYETB": 7.615246,
    "CNYEUR": 0.124031,
    "CNYFJD": 0.305691,
    "CNYFKP": 0.106502,
    "CNYGBP": 0.106847,
    "CNYGEL": 0.357223,
    "CNYGGP": 0.106502,
    "CNYGHS": 1.5828,
    "CNYGIP": 0.106502,
    "CNYGMD": 8.307413,
    "CNYGNF": 1204.684651,
    "CNYGTQ": 1.09224,
    "CNYGYD": 29.272432,
    "CNYHKD": 1.088248,
    "CNYHNL": 3.439929,
    "CNYHRK": 0.936431,
    "CNYHTG": 19.224961,
    "CNYHUF": 46.350456,
    "CNYIDR": 2087.725446,
    "CNYILS": 0.499913,
    "CNYIMP": 0.106502,
    "CNYINR": 11.430668,
    "CNYIQD": 182.44357,
    "CNYIRR": 5885.894561,
    "CNYISK": 18.170498,
    "CNYJEP": 0.106502,
    "CNYJMD": 21.517714,
    "CNYJOD": 0.098784,
    "CNYJPY": 19.362974,
    "CNYKES": 19.721278,
    "CNYKGS": 12.23766,
    "CNYKHR": 575.045386,
    "CNYKMF": 61.146485,
    "CNYKPW": 125.343106,
    "CNYKRW": 176.21688,
    "CNYKWD": 0.042681,
    "CNYKYD": 0.11609,
    "CNYKZT": 61.82747,
    "CNYLAK": 2660.055085,
    "CNYLBP": 2125.258664,
    "CNYLKR": 45.070685,
    "CNYLRD": 25.730176,
    "CNYLSL": 2.487392,
    "CNYLTL": 0.411228,
    "CNYLVL": 0.084243,
    "CNYLYD": 0.658765,
    "CNYMAD": 1.35652,
    "CNYMDL": 2.514652,
    "CNYMGA": 627.410901,
    "CNYMKD": 7.630174,
    "CNYMMK": 292.558243,
    "CNYMNT": 480.331235,
    "CNYMOP": 1.120914,
    "CNYMRO": 49.719331,
    "CNYMUR": 6.302004,
    "CNYMVR": 2.145316,
    "CNYMWK": 146.163317,
    "CNYMXN": 2.333419,
    "CNYMYR": 0.632634,
    "CNYMZN": 8.808757,
    "CNYNAD": 2.48732,
    "CNYNGN": 109.953284,
    "CNYNIO": 5.087568,
    "CNYNOK": 1.400199,
    "CNYNPR": 18.286097,
    "CNYNZD": 0.221184,
    "CNYOMR": 0.053605,
    "CNYPAB": 0.139307,
    "CNYPEN": 0.496071,
    "CNYPGK": 0.490924,
    "CNYPHP": 7.571682,
    "CNYPKR": 39.134898,
    "CNYPLN": 0.551904,
    "CNYPYG": 1011.924735,
    "CNYQAR": 0.508358,
    "CNYRON": 0.612955,
    "CNYRSD": 14.536996,
    "CNYRUB": 12.67352,
    "CNYRWF": 163.154689,
    "CNYSAR": 0.522303,
    "CNYSBD": 1.164545,
    "CNYSCR": 1.81493,
    "CNYSDG": 83.631879,
    "CNYSEK": 1.42166,
    "CNYSGD": 0.18423,
    "CNYSHP": 0.169457,
    "CNYSLE": 2.800935,
    "CNYSLL": 2750.580597,
    "CNYSOS": 79.314216,
    "CNYSRD": 5.326029,
    "CNYSTD": 2882.605759,
    "CNYSVC": 1.218957,
    "CNYSYP": 349.921382,
    "CNYSZL": 2.487358,
    "CNYTHB": 4.743498,
    "CNYTJS": 1.524086,
    "CNYTMT": 0.487445,
    "CNYTND": 0.421918,
    "CNYTOP": 0.324478,
    "CNYTRY": 3.753713,
    "CNYTTD": 0.944966,
    "CNYTWD": 4.306641,
    "CNYTZS": 340.514924,
    "CNYUAH": 5.145379,
    "CNYUGX": 510.603089,
    "CNYUSD": 0.13927,
    "CNYUYU": 5.300299,
    "CNYUZS": 1619.012627,
    "CNYVEF": 395800.549215,
    "CNYVES": 3.987807,
    "CNYVND": 3292.688626,
    "CNYVUV": 16.30755,
    "CNYWST": 0.375178,
    "CNYXAF": 81.17492,
    "CNYXAG": 0.00556,
    "CNYXAU": 0.000070429394,
    "CNYXCD": 0.376384,
    "CNYXDR": 0.102848,
    "CNYXOF": 81.40299,
    "CNYXPF": 14.867072,
    "CNYYER": 34.858948,
    "CNYZAR": 2.490076,
    "CNYZMK": 1253.59625,
    "CNYZMW": 2.633083,
    "CNYZWL": 44.844851
  }
}
```

The origin handling logic, it will affect the `getDate()` result from the returned `ExchangeRate` implement object.

```php
// line 132
$date = (new \DateTime())->setTimestamp($data['timestamp']);
```

Here is a fixed logic I made PR:

```php
// line 132
// history exchange rate responses `date` while latest exchange rate does not
// history exchange rate responses `timestamp`, it's not correct, should use `date` instead
if (isset($data['date'])) {
    $date = new \DateTime($data['date']);
} else {
    $date = (new \DateTime())->setTimestamp($data['timestamp']);
}
```

From the official document of currency layer(https://currencylayer.com/documentation), it proves that meaning.

> date | [Required] Specify a date for which to request historical rates. (Format: YYYY-MM-DD)
> timestamp | Returns the exact date and time (UNIX) the exchange rates were collected.