### PR TITLE
:beetle: Fixed external abstract api url

### DIFF
--- a/src/Service/AbstractApi.php
+++ b/src/Service/AbstractApi.php
@@ -33,7 +33,7 @@ final class AbstractApi extends HttpService
 
     const API_KEY_OPTION = 'api_key';
 
-    const LATEST_URL = 'https://exchange-rates.abstractapi.com/v1/live?api_key=%s&base=%s';
+    const LATEST_URL = 'https://exchange-rates.abstractapi.com/v1/live/?api_key=%s&base=%s';
 
     const HISTORICAL_URL = 'https://exchange-rates.abstractapi.com/v1/historical?api_key=%s&base=%s&date=%s';
 

--- a/tests/Tests/Service/AbstractApiTest.php
+++ b/tests/Tests/Service/AbstractApiTest.php
@@ -38,7 +38,7 @@ class AbstractApiTest extends ServiceTestCase
     public function it_throws_an_exception_when_rate_not_supported()
     {
         $this->expectException(Exception::class);
-        $url = 'https://exchange-rates.abstractapi.com/v1/live?api_key=secret&base=USD';
+        $url = 'https://exchange-rates.abstractapi.com/v1/live/?api_key=secret&base=USD';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/AbstractApi/success.json');
         $service = new AbstractApi($this->getHttpAdapterMock($url, $content), null, ['api_key' => 'secret']);
 
@@ -51,7 +51,7 @@ class AbstractApiTest extends ServiceTestCase
     public function it_fetches_a_rate()
     {
         $pair = CurrencyPair::createFromString('USD/GBP');
-        $url = 'https://exchange-rates.abstractapi.com/v1/live?api_key=secret&base=USD';
+        $url = 'https://exchange-rates.abstractapi.com/v1/live/?api_key=secret&base=USD';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/AbstractApi/success.json');
         $service = new AbstractApi($this->getHttpAdapterMock($url, $content), null, ['api_key' => 'secret']);
 


### PR DESCRIPTION
# Changes
- The external API url of the Abstract api had a typo, or they might have recently changed it on their end
@florianv See the provided url in the [abstract dashboard](https://app.abstractapi.com/api/exchange-rates/tester)