### PR TITLE
chore: add testruns for PHP 8.1, 8.2, 8.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
         - php: 7.3
         - php: 7.4
         - php: 8.0
+        - php: 8.1
+        - php: 8.2
+        - php: 8.3
 
 cache:
   directories:

--- a/composer.json
+++ b/composer.json
@@ -50,5 +50,10 @@
     "suggest": {
         "php-http/message": "Required to use Guzzle for sending HTTP requests",
         "php-http/guzzle6-adapter": "Required to use Guzzle for sending HTTP requests"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }


### PR DESCRIPTION
I am not sure, if travis is still active used.