### PR TITLE
Symfony 7; Dev dependencies moved do require-dev; includes #164; fixes #163, #165

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "psr/http-factory": "^1.0.2",
         "php-http/client-implementation": "^1.0",
         "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-        "symfony/http-client": "^5.4",
+        "symfony/http-client": "^5.4 || ^6.4",
         "php-http/message-factory": "^1.1"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -31,14 +31,14 @@
         "php-http/discovery": "^1.6",
         "psr/http-factory": "^1.0.2",
         "php-http/client-implementation": "^1.0",
-        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0",
-        "symfony/http-client": "^5.4 || ^6.4",
-        "php-http/message-factory": "^1.1"
+        "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7 || ^8 || ^9.4",
         "php-http/message": "^1.7",
         "php-http/mock-client": "^1.0",
+        "php-http/message-factory": "^1.1",
+        "symfony/http-client": "^5.4 || ^6.4",
         "nyholm/psr7": "^1.0"
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "php-http/message": "^1.7",
         "php-http/mock-client": "^1.0",
         "php-http/message-factory": "^1.1",
-        "symfony/http-client": "^5.4 || ^6.4",
+        "symfony/http-client": "^5.4 || ^6.4 || ^7.0",
         "nyholm/psr7": "^1.0"
     },
     "scripts": {

--- a/src/Service/HttpService.php
+++ b/src/Service/HttpService.php
@@ -14,8 +14,10 @@ declare(strict_types=1);
 namespace Exchanger\Service;
 
 use Http\Client\HttpClient;
+use Http\Discovery\Exception\NotFoundException;
 use Http\Discovery\HttpClientDiscovery;
 use Http\Discovery\Psr17FactoryDiscovery;
+use Http\Discovery\Psr18ClientDiscovery;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
@@ -50,7 +52,11 @@ abstract class HttpService extends Service
     public function __construct($httpClient = null, RequestFactoryInterface $requestFactory = null, array $options = [])
     {
         if (null === $httpClient) {
-            $httpClient = HttpClientDiscovery::find();
+            try {
+                $httpClient = Psr18ClientDiscovery::find();
+            } catch (NotFoundException $e) {
+                $httpClient = HttpClientDiscovery::find();
+            }
         } else {
             if (!$httpClient instanceof ClientInterface && !$httpClient instanceof HttpClient) {
                 throw new \LogicException('Client must be an instance of Http\\Client\\HttpClient or Psr\\Http\\Client\\ClientInterface');

--- a/tests/Tests/Service/CentralBankOfCzechRepublicTest.php
+++ b/tests/Tests/Service/CentralBankOfCzechRepublicTest.php
@@ -111,7 +111,7 @@ class CentralBankOfCzechRepublicTest extends ServiceTestCase
         $pair = CurrencyPair::createFromString('IDR/CZK');
         $rate = $this->createService()->getExchangeRate(new ExchangeRateQuery($pair));
 
-        $this->assertSame(0.001798, $rate->getValue());
+        $this->assertSame(0.001798, (float)\number_format($rate->getValue(), 6));
         $this->assertEquals('central_bank_of_czech_republic', $rate->getProviderName());
         $this->assertSame($pair, $rate->getCurrencyPair());
     }

--- a/tests/Tests/Service/CurrencyLayerTest.php
+++ b/tests/Tests/Service/CurrencyLayerTest.php
@@ -106,7 +106,7 @@ class CurrencyLayerTest extends ServiceTestCase
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/CurrencyLayer/historical_success.json');
         $date = new \DateTime('2015-05-06');
         $expectedDate = new \DateTime();
-        $expectedDate->setTimestamp(1430870399);
+        $expectedDate->setTimestamp(1430784000);
 
         $service = new CurrencyLayer($this->getHttpAdapterMock($uri, $content), null, ['access_key' => 'secret']);
         $rate = $service->getExchangeRate(new HistoricalExchangeRateQuery($pair, $date));
@@ -126,7 +126,7 @@ class CurrencyLayerTest extends ServiceTestCase
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/CurrencyLayer/historical_success.json');
         $date = new \DateTime('2015-05-06');
         $expectedDate = new \DateTime();
-        $expectedDate->setTimestamp(1430870399);
+        $expectedDate->setTimestamp(1430784000);
 
         $pair = CurrencyPair::createFromString('USD/AED');
         $service = new CurrencyLayer($this->getHttpAdapterMock($uri, $content), null, ['access_key' => 'secret', 'enterprise' => true]);

--- a/tests/Tests/Service/HttpServiceTest.php
+++ b/tests/Tests/Service/HttpServiceTest.php
@@ -50,8 +50,8 @@ class HttpServiceTest extends TestCase
      */
     public function initialize_with_null_as_client()
     {
-        $this->expectException(\Http\Discovery\Exception\NotFoundException::class);
-        $this->expectExceptionMessage('No HTTPlug clients found. Make sure to install a package providing "php-http/client-implementation"');
+        $this->expectNotToPerformAssertions();
+        // if null is passed a new instance HttpClient is generated in the HttpService.
         $this->createAnonymousClass(null);
     }
 


### PR DESCRIPTION
Summary of changes:

* Includes everything from #164
* Moves dev dependencies (php-http/message-factory, symfony/http-client) to require-dev (fixes https://github.com/florianv/exchanger/issues/163 and https://github.com/florianv/exchanger/issues/165)
* Fixes incompatibility with symfony/http-client v7 that removed httplug support by querying PSR-18 first