### PR TITLE
Improve README, documentation, and discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,56 +5,205 @@
 [![Total Downloads](https://img.shields.io/packagist/dt/florianv/exchanger.svg?style=flat-square)](https://packagist.org/packages/florianv/exchanger)
 [![Version](http://img.shields.io/packagist/v/florianv/exchanger.svg?style=flat-square)](https://packagist.org/packages/florianv/exchanger)
 
-Exchanger is a PHP framework to work with currency exchange rates from various services such as
-**[Fixer](https://fixer.io)**, **[Currency Data](https://currencylayer.com)**
-or **[Exchange Rates Data](https://exchangeratesapi.io)**.
-Looking for a simple library based on Exchanger ? Check out [Swap](https://github.com/florianv/swap) !
+> _Exchange rate provider layer for PHP. Direct access to 30 provider implementations through a single `ExchangeRateService` interface, with chain fallback and PSR-16 caching. Maintained since 2016._
 
-## Documentation
+Exchanger is the **exchange rate provider layer** for PHP. It exposes 30 services (the European Central Bank, several national banks, exchangerate.host, and commercial **exchange rate APIs** that require an API key) behind a single `ExchangeRateService` interface, with chainable fallback, PSR-16 caching, and historical rates. Used in real-world PHP applications since 2016.
 
-The documentation for the current branch can be found [here](https://github.com/florianv/exchanger/blob/master/doc/readme.md).
+For most use cases, the higher-level [Swap](https://github.com/florianv/swap) library is what you want. Reach for Exchanger directly when you need finer control.
 
-## Services
+## 💡 What is Exchanger?
 
-Here is the complete list of the currently implemented services:
+- Exchanger is a PHP library for currency conversion and exchange rate retrieval at the provider layer.
+- It contains 30 service implementations behind a common `ExchangeRateService` interface.
+- It caches results via PSR-16 SimpleCache.
+- It supports historical rates.
+- It supports a chain service for fallback. When a service errors, the next one in the chain is tried.
 
-| Service | Base Currency | Quote Currency | Historical |
-|---------------------------------------------------------------------------|----------------------|----------------|----------------|
-| [Fixer](https://fixer.io) | EUR (free, no SSL), * (paid) | * | Yes |
-| [Currency Data](https://currencylayer.com) | USD (free), * (paid) | * | Yes |
-| [Exchange Rates Data](https://exchangeratesapi.io) | USD (free), * (paid) | * | Yes |
-| [Abstract](https://www.abstractapi.com) | * | * | Yes |
-| [coinlayer](https://coinlayer.com) | * Crypto (Limited standard currencies) | * Crypto (Limited standard currencies) | Yes |
-| [Fixer](https://fixer.io) | EUR (free, no SSL), * (paid) | * | Yes |
-| [currencylayer](https://currencylayer.com) | USD (free), * (paid) | * | Yes |
-| [exchangeratesapi](https://exchangeratesapi.io) | USD (free), * (paid) | * | Yes |
-| [European Central Bank](https://www.ecb.europa.eu/home/html/index.en.html) | EUR | * | Yes |
-| [National Bank of Georgia](https://nbg.gov.ge) | * | GEL | Yes |
-| [National Bank of the Republic of Belarus](https://www.nbrb.by) | * | BYN (from 01-07-2016),<br>BYR (01-01-2000 - 30-06-2016),<br>BYB (25-05-1992 - 31-12-1999) | Yes |
-| [National Bank of Romania](http://www.bnr.ro) | RON, AED, AUD, BGN, BRL, CAD, CHF, CNY, CZK, DKK, EGP, EUR, GBP, HRK, HUF, INR, JPY, KRW, MDL, MXN, NOK, NZD, PLN, RSD, RUB, SEK, TRY, UAH, USD, XAU, XDR, ZAR | RON, AED, AUD, BGN, BRL, CAD, CHF, CNY, CZK, DKK, EGP, EUR, GBP, HRK, HUF, INR, JPY, KRW, MDL, MXN, NOK, NZD, PLN, RSD, RUB, SEK, TRY, UAH, USD, XAU, XDR, ZAR | Yes |
-| [National Bank of Ukranie](https://bank.gov.ua) | * | UAH | Yes |
-| [Central Bank of the Republic of Turkey](http://www.tcmb.gov.tr) | * | TRY | Yes |
-| [Central Bank of the Republic of Uzbekistan](https://cbu.uz) | * | UZS | Yes |
-| [Central Bank of the Czech Republic](https://www.cnb.cz) | * | CZK | Yes |
-| [Central Bank of Russia](https://cbr.ru) | * | RUB | Yes |
-| [Bulgarian National Bank](http://bnb.bg) | * | BGN | Yes |
-| [WebserviceX](http://www.webservicex.net) | * | * | No |
-| [1Forge](https://1forge.com) | * (free but limited or paid) | * (free but limited or paid) | No |
-| [Cryptonator](https://www.cryptonator.com) | * Crypto (Limited standard currencies) | * Crypto (Limited standard currencies)  | No |
-| [CurrencyDataFeed](https://currencydatafeed.com) | * (free but limited or paid) | * (free but limited or paid) | No |
-| [Open Exchange Rates](https://openexchangerates.org) | USD (free), * (paid) | * | Yes |
-| [Xignite](https://www.xignite.com) | * | * | Yes |
-| [Currency Converter API](https://www.currencyconverterapi.com) | * | * | Yes (free but limited or paid) |
-| [xChangeApi.com](https://xchangeapi.com) | * | * | Yes |
-| [fastFOREX.io](https://www.fastforex.io) | USD (free), * (paid) | * | No |
-| [exchangerate.host](https://www.exchangerate.host) | * | * | Yes |
-| Array | * | * | Yes |
+## 🎯 When should you use Exchanger?
 
-## Credits
+- Use Exchanger when you need finer control than [Swap](https://github.com/florianv/swap) exposes: custom chain composition, custom caching strategy, custom HTTP middleware, or building your own facade or framework integration.
+- For most PHP applications, use [Swap](https://github.com/florianv/swap) instead. It is built on Exchanger and provides sensible defaults and a builder-style API.
 
-- [Florian Voutzinos](https://github.com/florianv)
-- [All Contributors](https://github.com/florianv/exchanger/contributors)
+## 🧠 Why Exchanger over Swap?
 
-## License
+Swap is the easy-to-use, high-level API. Exchanger is the layer Swap is built on.
+
+Reach for Exchanger directly when:
+
+- **Custom facade:** you want to build your own currency conversion API on top of the provider layer.
+- **Framework binding:** you are integrating into a framework that does not yet have a Swap binding.
+- **Fine-grained chain composition:** you need to wrap services with custom logic (rate limiting, observability, conditional fallback) before chaining them.
+- **Direct cache control:** you want to manage the PSR-16 cache key strategy yourself.
+- **Custom HTTP layer:** you need an HTTP middleware stack the Swap builder does not expose.
+
+If none of these apply, use Swap.
+
+## 📦 Installation
+
+Exchanger requires PHP 8.2 or newer.
+
+```bash
+composer require florianv/exchanger symfony/http-client nyholm/psr7
+```
+
+Any PSR-18 client paired with a PSR-17 request factory works; `php-http/discovery` finds them automatically.
+
+## ⚡ Quickstart
+
+```php
+use Exchanger\Exchanger;
+use Exchanger\ExchangeRateQueryBuilder;
+use Exchanger\Service\EuropeanCentralBank;
+
+// The European Central Bank is free, no API key required.
+$service   = new EuropeanCentralBank();
+$exchanger = new Exchanger($service);
+
+// EUR → USD exchange rate
+$query = (new ExchangeRateQueryBuilder('EUR/USD'))->build();
+$rate  = $exchanger->getExchangeRate($query);
+
+$rate->getValue();                 // e.g. 1.0823 (a float)
+$rate->getDate()->format('Y-m-d'); // e.g. 2026-04-29
+$rate->getProviderName();          // 'european_central_bank'
+
+// Convert an amount using the returned rate
+$amountInEUR = 100.00;
+$amountInUSD = $amountInEUR * $rate->getValue();
+
+// Historical rate
+$query = (new ExchangeRateQueryBuilder('EUR/USD'))
+    ->setDate((new \DateTime())->modify('-15 days'))
+    ->build();
+
+$rate = $exchanger->getExchangeRate($query);
+```
+
+Exchanger retrieves the rate; your application multiplies the amount by `$rate->getValue()` to perform the conversion.
+
+## 🔁 Chaining services (fallback chain)
+
+Wrap multiple services in a `Chain` to fall back when one of them errors:
+
+```php
+use Exchanger\Exchanger;
+use Exchanger\Service\Chain;
+use Exchanger\Service\EuropeanCentralBank;
+
+$service = new Chain([
+    new YourPrimaryService(null, null, ['api_key' => 'YOUR_KEY']),
+    new YourFallbackService(null, null, ['api_key' => 'YOUR_KEY']),
+    new EuropeanCentralBank(), // free fallback for EUR-base pairs
+]);
+
+$exchanger = new Exchanger($service);
+```
+
+Services are tried in order. If a service does not support the requested currency pair, it is skipped silently. If a service throws an exception, the exception is collected and the next service is tried. If every service was skipped or threw, the chain raises an `Exchanger\Exception\ChainException` containing all collected exceptions.
+
+## 🛠 Common use cases
+
+- Build your own currency conversion facade on top of the provider layer.
+- Integrate Exchanger into a framework that does not yet have a Swap binding.
+- Wrap services with custom middleware (rate limiting, observability, request signing) before chaining.
+- Power internal FX dashboards with full control over the cache key strategy.
+- Implement custom HTTP layers (signed requests, mTLS, custom retries) on top of any PSR-18 client.
+
+## 🧭 Which package should I use?
+
+The Swap ecosystem is a layered toolkit for currency conversion in PHP:
+
+- **Swap.** The easy-to-use, high-level API. Most apps need only Swap.
+- **Exchanger.** The lower-level, more granular layer Swap is built on (this package). Reach for it when you need finer control over chain composition, caching, or HTTP plumbing.
+- **Laravel Swap.** Laravel application of Swap.
+- **Symfony Swap.** Symfony integration of Swap.
+
+All four packages are MIT-licensed and require PHP 8.2 or newer.
+
+## 📊 Providers
+
+Exchanger ships 30 exchange rate provider implementations. Each is registered in `Exchanger\Service\Registry` under the **identifier** shown in the table.
+
+### Public providers (no API key required)
+
+| Service                                    | Identifier                            | Base           | Quote          | Historical |
+| ------------------------------------------ | ------------------------------------- | -------------- | -------------- | ---------- |
+| Bulgarian National Bank                    | `bulgarian_national_bank`             | *              | BGN            | Yes        |
+| Central Bank of the Czech Republic         | `central_bank_of_czech_republic`      | *              | CZK            | Yes        |
+| Central Bank of the Republic of Turkey     | `central_bank_of_republic_turkey`     | *              | TRY            | Yes        |
+| Central Bank of the Republic of Uzbekistan | `central_bank_of_republic_uzbekistan` | *              | UZS            | Yes        |
+| Cryptonator                                | `cryptonator`                         | * (crypto)     | * (crypto)     | No         |
+| European Central Bank                      | `european_central_bank`               | EUR            | *              | Yes        |
+| exchangerate.host                          | `exchangeratehost`                    | *              | *              | Yes        |
+| National Bank of Georgia                   | `national_bank_of_georgia`            | *              | GEL            | Yes        |
+| National Bank of Romania                   | `national_bank_of_romania`            | (limited list) | (limited list) | Yes        |
+| National Bank of the Republic of Belarus   | `national_bank_of_republic_belarus`   | *              | BYN            | Yes        |
+| National Bank of Ukraine                   | `national_bank_of_ukraine`            | *              | UAH            | Yes        |
+| Russian Central Bank                       | `russian_central_bank`                | *              | RUB            | Yes        |
+| WebserviceX                                | `webservicex`                         | *              | *              | No         |
+
+### Commercial providers (require an API key)
+
+| Service                          | Identifier                       | Base                  | Quote | Historical |
+| -------------------------------- | -------------------------------- | --------------------- | ----- | ---------- |
+| AbstractAPI                      | `abstract_api`                   | *                     | *     | Yes        |
+| coinlayer                        | `coin_layer`                     | * (crypto)            | *     | Yes        |
+| Currency Converter API           | `currency_converter`             | *                     | *     | Yes        |
+| Currency Data (APILayer)         | `apilayer_currency_data`         | USD (free), * (paid)  | *     | Yes        |
+| CurrencyDataFeed                 | `currency_data_feed`             | *                     | *     | No         |
+| currencylayer (direct)           | `currency_layer`                 | USD (free), * (paid)  | *     | Yes        |
+| Exchange Rates Data (APILayer)   | `apilayer_exchange_rates_data`   | USD (free), * (paid)  | *     | Yes        |
+| exchangeratesapi (direct)        | `exchange_rates_api`             | USD (free), * (paid)  | *     | Yes        |
+| fastFOREX.io                     | `fastforex`                      | USD (free), * (paid)  | *     | No         |
+| Fixer (APILayer)                 | `apilayer_fixer`                 | EUR (free), * (paid)  | *     | Yes        |
+| Fixer (direct)                   | `fixer`                          | EUR (free), * (paid)  | *     | Yes        |
+| 1Forge                           | `forge`                          | *                     | *     | No         |
+| Open Exchange Rates              | `open_exchange_rates`            | USD (free), * (paid)  | *     | Yes        |
+| xChangeApi.com                   | `xchangeapi`                     | *                     | *     | Yes        |
+| Xignite                          | `xignite`                        | *                     | *     | Yes        |
+
+You can also add your own provider by implementing the `Exchanger\Contract\ExchangeRateService` interface (see the [documentation](doc/readme.md)).
+
+## ⚙ Caching, HTTP client, and error handling
+
+- **Caching:** PSR-16 `SimpleCache` is passed as the second constructor argument: `new Exchanger($service, $cache)`. Per-query disable: `->addOption('cache', false)`. Per-query TTL: `->addOption('cache_ttl', 3600)`.
+- **HTTP client:** any PSR-18 client (`symfony/http-client`, `php-http/guzzle7-adapter`, etc.). Pass it explicitly to each service constructor, or rely on `php-http/discovery` to auto-discover.
+- **Errors:** when every service in a `Chain` has either skipped (unsupported pair) or thrown, the chain raises an `Exchanger\Exception\ChainException` containing all collected exceptions.
+
+## 📚 Documentation
+
+The full documentation, with the per-provider configuration reference, caching options, and how to write your own service, is in [doc/readme.md](doc/readme.md).
+
+## 🧩 Related packages
+
+The Swap ecosystem:
+
+- [**Swap**](https://github.com/florianv/swap): easy-to-use PHP currency conversion library.
+- [**Exchanger**](https://github.com/florianv/exchanger): exchange rate provider layer (this package).
+- [**Laravel Swap**](https://github.com/florianv/laravel-swap): Laravel application of Swap.
+- [**Symfony Swap**](https://github.com/florianv/symfony-swap): Symfony integration of Swap.
+
+## 🤝 Sponsorship
+
+The Swap ecosystem is open to selected sponsorships from exchange rate API providers and financial infrastructure companies.
+
+Sponsorship can include:
+
+- Documentation visibility
+- Integration examples
+- Ecosystem-level visibility across Swap, Exchanger, Laravel Swap, and Symfony Swap
+
+For inquiries, contact the maintainer via [GitHub](https://github.com/florianv).
+
+## 🙌 Contributing
+
+Issues and pull requests are welcome. Please see the existing [issues](https://github.com/florianv/exchanger/issues) before opening a new one.
+
+## 📄 License
 
 The MIT License (MIT). Please see [LICENSE](https://github.com/florianv/exchanger/blob/master/LICENSE) for more information.
+
+## 👏 Credits
+
+- [Florian Voutzinos](https://github.com/florianv)
+- [All contributors](https://github.com/florianv/exchanger/contributors)

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,16 @@
 {
     "name": "florianv/exchanger",
     "type": "library",
-    "description": "Currency exchange rates framework for PHP",
+    "description": "PHP exchange rate provider layer for currency conversion: 30 services, chain fallback, and caching.",
     "keywords": [
-        "currency",
-        "money",
-        "rate",
-        "conversion",
-        "exchange rates"
+        "php",
+        "currency-conversion",
+        "exchange-rates",
+        "exchange-rate-api",
+        "forex",
+        "fallback",
+        "swap",
+        "money"
     ],
     "homepage": "https://github.com/florianv/exchanger",
     "license": "MIT",

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -132,7 +132,7 @@ use Exchanger\ExchangeRateQueryBuilder;
 $query = (new ExchangeRateQueryBuilder('EUR/USD'))->build();
 ```
 
-> Currencies are expressed as their [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) code.
+> Currencies are expressed as their [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) code.
 
 ### Latest and historical rates
 

--- a/doc/readme.md
+++ b/doc/readme.md
@@ -1,306 +1,337 @@
 # Documentation
 
-## Sponsors
+## 💡 What is Exchanger?
 
-<table>
-   <tr>
-      <td><img src="https://assets.apilayer.com/apis/fixer.png" width="50px"/></td>
-      <td><a href="https://fixer.io">Fixer</a> is a simple and lightweight API for foreign exchange rates that supports up to 170 world currencies.</td>
-   </tr>
-   <tr>
-     <td><img src="https://assets.apilayer.com/apis/currency_data.png" width="50px"/></td>
-     <td><a href="https://currencylayer.com">Currency Data</a> provides reliable exchange rates and currency conversions for your business up to 168 world currencies.</td>
-   </tr>
-   <tr>
-     <td><img src="https://assets.apilayer.com/apis/exchangerates_data.png" width="50px"/></td>
-     <td><a href="https://exchangeratesapi.io">Exchange Rates Data</a> provides reliable exchange rates and currency conversions for your business with over 15 data sources.</td>
-   </tr>
-</table>
+- Exchanger is a PHP library for currency conversion and exchange rate retrieval at the provider layer.
+- It contains 30 service implementations behind a common `ExchangeRateService` interface.
+- It caches results via PSR-16 SimpleCache.
+- It supports historical rates.
+- It supports a chain service for fallback. When a service errors, the next one in the chain is tried.
+
+For the wider ecosystem (Swap, Laravel Swap, Symfony Swap), see the [README](../README.md).
+
+## 🎯 When should you use Exchanger?
+
+- Use Exchanger when you need finer control than [Swap](https://github.com/florianv/swap) exposes: custom chain composition, custom caching strategy, custom HTTP middleware, or building your own facade or framework integration.
+- For most PHP applications, use [Swap](https://github.com/florianv/swap) instead. It is built on Exchanger and provides sensible defaults and a builder-style API.
+
+## 🧠 Why Exchanger over Swap?
+
+Swap is the easy-to-use, high-level API. Exchanger is the layer Swap is built on.
+
+Reach for Exchanger directly when:
+
+- **Custom facade:** you want to build your own currency conversion API on top of the provider layer.
+- **Framework binding:** you are integrating into a framework that does not yet have a Swap binding.
+- **Fine-grained chain composition:** you need to wrap services with custom logic before chaining.
+- **Direct cache control:** you want to manage the PSR-16 cache strategy yourself.
+- **Custom HTTP layer:** you need an HTTP middleware stack the Swap builder does not expose.
+
+If none of these apply, use Swap.
 
 ## Index
 
-* [Installation](#installation)
-* [Configuration](#configuration)
-* [Usage](#usage)
-  * [Latest Rates](#latest-rates)
-  * [Historical Rates](#historical-rates)
-* [Chaining Services](#chaining-services)
-    * [Rate Provider](#rate-provider)
-* [Caching](#caching)
-  * [Rates Caching](#rates-caching)
-   * [Query Cache Options](#query-cache-options)
-  * [Requests Caching](#requests-caching)
-* [Creating a Service](#creating-a-service)
-  * [Standard Service](#standard-service)
-  * [Historical Service](#historical-service)
-* [Supported Services](#supported-services)
+* [Installation](#-installation)
+* [Configuration](#-configuration)
+  * [Building Exchanger](#building-exchanger)
+  * [Chaining services](#chaining-services)
+  * [How the chain works](#how-the-chain-works)
+* [Usage](#-usage)
+  * [Building queries](#building-queries)
+  * [Latest and historical rates](#latest-and-historical-rates)
+  * [Inspecting the rate](#inspecting-the-rate)
+* [Caching](#-caching)
+  * [PSR-16 SimpleCache (minimal setup)](#psr-16-simplecache-minimal-setup)
+  * [Per-query options](#per-query-options)
+  * [HTTP request caching](#http-request-caching)
+* [Provider configuration](#-provider-configuration)
+* [Creating a custom service](#-creating-a-custom-service)
+  * [Standard service](#standard-service)
+  * [Historical service](#historical-service)
+* [FAQ](#-faq)
 
-## Installation
+## 📦 Installation
 
-Exchanger is decoupled from any library sending HTTP requests (like Guzzle), instead it uses an abstraction called [HTTPlug](http://httplug.io/) 
-which provides the http layer used to send requests to exchange rate services. 
-This gives you the flexibility to choose what HTTP client and PSR-7 implementation you want to use.
+Exchanger requires PHP 8.2 or newer. It does not bundle an HTTP client; any PSR-18 client paired with a PSR-17 request factory works, and `php-http/discovery` finds them automatically.
 
-Read more about the benefits of this and about what different HTTP clients you may use in the [HTTPlug documentation](http://docs.php-http.org/en/latest/httplug/users.html). 
-Below is an example using the curl client:
+The simplest modern install:
 
 ```bash
-composer require php-http/curl-client nyholm/psr7 php-http/message florianv/exchanger
+composer require florianv/exchanger symfony/http-client nyholm/psr7
 ```
 
-## Configuration
+Other PSR-18 clients work the same way, for example Guzzle 7:
 
-First, you need to create a **service** and add it to `Exchanger`.
+```bash
+composer require florianv/exchanger php-http/guzzle7-adapter nyholm/psr7
+```
 
-We recommend to use one of the [services that support our project](#sponsors), providing a free plan up to 1,000 requests per day.
+You can also pass a client explicitly to each service constructor if you do not want auto-discovery.
 
-The complete list of all supported services is available [here](https://github.com/florianv/exchanger/blob/master/README.md#services).
+## ⚙ Configuration
+
+### Building Exchanger
+
+`Exchanger` is constructed with a single service:
 
 ```php
-use Http\Client\Curl\Client as CurlClient;
-use Exchanger\Service\ApiLayer\CurrencyData;
-use Exchanger\Service\ApiLayer\ExchangeRatesData;
-use Exchanger\Service\ApiLayer\Fixer;
 use Exchanger\Exchanger;
+use Exchanger\Service\EuropeanCentralBank;
 
-// Create your http client (we choose curl here)
-$options = [
-    CURLOPT_FOLLOWLOCATION => true,
-];
-$client = new CurlClient(null, null, $options);
-
-// Use the Fixer service
-$service = new Fixer($client, null, ['api_key' => 'Get your key here: https://fixer.io']);
-
-// Or use the CurrencyData service
-$service = new CurrencyData($client, null, ['api_key' => 'Get your key here: https://currencylayer.com']);
-
-// Or use the ExchangeRatesData service
-$service = new ExchangeRatesData($client, null, ['api_key' => 'Get your key here: https://exchangeratesapi.io']);
-
-// Create Exchanger with your service
+$service   = new EuropeanCentralBank();
 $exchanger = new Exchanger($service);
 ```
 
-### Usage
+Service constructors take an HTTP client (any PSR-18 client) as the first argument and a PSR-17 request factory as the second; both can be left `null` to auto-discover. The third argument is the per-service options array. For example:
 
-#### Latest Rates
+```php
+use Exchanger\Service\OpenExchangeRates;
 
-`Exchanger` uses a concept of queries. In order to get an exchange rate, you need to build a **query** and `Exchanger` will process it to return the rate. 
-The example below shows how to get the **latest** `EUR/USD` exchange rate.
+$service = new OpenExchangeRates(null, null, ['app_id' => 'YOUR_APP_ID']);
+```
+
+Per-service option keys are documented in the [Provider configuration](#-provider-configuration) section.
+
+### Chaining services
+
+Wrap multiple services in a `Chain` to fall back when one of them errors:
+
+```php
+use Exchanger\Exchanger;
+use Exchanger\Service\Chain;
+use Exchanger\Service\EuropeanCentralBank;
+
+$service = new Chain([
+    new YourPrimaryService(null, null, ['api_key' => 'YOUR_KEY']),
+    new YourFallbackService(null, null, ['api_key' => 'YOUR_KEY']),
+    new EuropeanCentralBank(), // free fallback for EUR-base pairs
+]);
+
+$exchanger = new Exchanger($service);
+```
+
+### How the chain works
+
+The `Chain` calls services in declaration order. For each service:
+
+1. If the service does not support the requested currency pair, it is skipped silently.
+2. If the service throws an exception, the exception is collected and the next service is tried.
+3. If a service returns a rate, that rate is returned to the caller and the remaining services are not called.
+
+If every service was skipped or threw, the chain raises an `Exchanger\Exception\ChainException` containing all collected exceptions. The chain does not retry the same service, and there is no built-in delay between attempts.
+
+## ⚡ Usage
+
+### Building queries
+
+Exchanger uses a query object built with `ExchangeRateQueryBuilder`:
 
 ```php
 use Exchanger\ExchangeRateQueryBuilder;
 
-// Create the query to get the latest EUR/USD rate
-$query = (new ExchangeRateQueryBuilder('EUR/USD'))
-    ->build();
-
-// Get the exchange rate
-$rate = $exchanger->getExchangeRate($query);
-
-// 1.1159
-echo $rate->getValue();
-
-// 2016-09-06
-echo $rate->getDate()->format('Y-m-d');
+$query = (new ExchangeRateQueryBuilder('EUR/USD'))->build();
 ```
 
 > Currencies are expressed as their [ISO 4217](http://en.wikipedia.org/wiki/ISO_4217) code.
 
-#### Historical Rates
-
-`Exchanger` allows you to retrieve **historical** exchange rates but not all services support this feature as you can see in this [table](https://github.com/florianv/exchanger/blob/master/README.md#services).
+### Latest and historical rates
 
 ```php
-// Create the query to get the EUR/USD rate 15 days ago
+// Latest rate
+$query = (new ExchangeRateQueryBuilder('EUR/USD'))->build();
+$rate  = $exchanger->getExchangeRate($query);
+
+echo $rate->getValue();                 // e.g. 1.0823
+echo $rate->getDate()->format('Y-m-d'); // e.g. 2026-04-29
+
+// Historical rate
 $query = (new ExchangeRateQueryBuilder('EUR/USD'))
     ->setDate((new \DateTime())->modify('-15 days'))
     ->build();
 
-// Get the exchange rate
 $rate = $exchanger->getExchangeRate($query);
-
-// 1.1339
-echo $rate->getValue();
-
-// 2016-08-23
-echo $rate->getDate()->format('Y-m-d');
 ```
 
-### Chaining Services
+### Inspecting the rate
 
-It is possible to chain services in order to use fallbacks in case the previous ones don't support the currency or are unavailable.
-Simply create a `Chain` service to wrap the services you want to chain.
+The returned `Exchanger\Contract\ExchangeRate` exposes:
 
 ```php
-use Exchanger\Service\Chain;
-use Exchanger\Service\ApiLayer\CurrencyData;
-use Exchanger\Service\ApiLayer\ExchangeRatesData;
-use Exchanger\Service\ApiLayer\Fixer;
-
-$service = new Chain([
-    new Fixer($client, null, ['api_key' => 'Get your key here: https://fixer.io']),
-    new CurrencyData($client, null, ['api_key' => 'Get your key here: https://currencylayer.com']),
-    new ExchangeRatesData($client, null, ['api_key' => 'Get your key here: https://exchangeratesapi.io']),
-]);
+$rate->getValue();         // float
+$rate->getDate();          // DateTimeInterface
+$rate->getCurrencyPair();  // Exchanger\CurrencyPair
+$rate->getProviderName();  // string, the identifier of the service that returned the rate
 ```
 
-The rates will be first fetched using the `Fixer` service, will fallback to `CurrencyData`.
+`getProviderName()` is useful when several services are chained: the returned value is the identifier of the service that actually answered, for example `european_central_bank`.
 
-> You can consult the list of the supported services and their options [here](#supported-services)
+## 💾 Caching
 
-#### Rate provider
+### PSR-16 SimpleCache (minimal setup)
 
-When using the chain service, it can be useful to know which service provided the rate.
+Exchanger caches results through a PSR-16 `SimpleCache` passed as the second constructor argument. Any PSR-16 implementation works. A minimal Symfony Cache example:
 
-You can use the `getProviderName()` function on a rate that gives you the name of the service that returned it:
-
-```php
-$name = $rate->getProviderName();
+```bash
+composer require symfony/cache
 ```
 
-For example, if Fixer returned the rate, it will be identical to `fixer`.
-
-### Caching
-
-#### Rates Caching
-
-`Exchanger` provides a [PSR-16 Simple Cache](http://www.php-fig.org/psr/psr-16) integration allowing you to cache rates during a given time using the adapter of your choice.
-
-The following example uses the `Predis` cache from [php-cache.com](http://php-cache.com) PSR-6 implementation installable using `composer require cache/predis-adapter`.
-
-You will also need to install a "bridge" that allows to adapt the PSR-6 adapters to PSR-16 using `composer require cache/simple-cache-bridge` (https://github.com/php-cache/simple-cache-bridge).
-
 ```php
-use Cache\Adapter\Predis\PredisCachePool;
-use Cache\Bridge\SimpleCache\SimpleCacheBridge;
+use Exchanger\Exchanger;
+use Exchanger\Service\EuropeanCentralBank;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Psr16Cache;
 
-$client = new \Predis\Client('tcp:/127.0.0.1:6379');
-$psr6pool = new PredisCachePool($client);
-$simpleCache = new SimpleCacheBridge($psr6pool);
+$cache = new Psr16Cache(new FilesystemAdapter());
 
-$exchanger = new Exchanger($service, $simpleCache, ['cache_ttl' => 3600, 'cache_key_prefix' => 'myapp-']);
+$exchanger = new Exchanger(
+    new EuropeanCentralBank(),
+    $cache,
+    ['cache_ttl' => 3600, 'cache_key_prefix' => 'myapp-']
+);
 ```
 
-All rates will now be cached in Redis during 3600 seconds, and cache keys will be prefixed with 'myapp-'
+If only PSR-6 adapters are available, you can bridge them to PSR-16 with [`cache/simple-cache-bridge`](https://github.com/php-cache/simple-cache-bridge).
 
-##### Query Cache Options
+### Per-query options
 
-For more control, you can configure the cache per query.
+Cache behavior can be overridden per query via `addOption()` on the builder.
 
-###### cache_ttl
+| Option             | Type   | Default | Effect                                                                                                |
+| ------------------ | ------ | ------- | ----------------------------------------------------------------------------------------------------- |
+| `cache_ttl`        | int    | `null`  | Cache TTL in seconds. `null` means entries do not expire.                                             |
+| `cache`            | bool   | `true`  | Set to `false` to bypass the cache for this query.                                                    |
+| `cache_key_prefix` | string | `""`    | Prefix for the cache key. Max 24 characters (PSR-6 limits keys to 64 chars; the internal hash takes 40). |
 
-Set cache TTL in seconds. Default: `null` - cache entries permanently
+PSR-6 does not allow the characters `{}()/\@:` in keys; Exchanger replaces them with `-`.
 
 ```php
-// Override the global cache_ttl only for this query
-$query = (new ExchangeRateQueryBuilder('JPY/GBP'))
+$query = (new ExchangeRateQueryBuilder('EUR/USD'))
+    ->addOption('cache', false)
+    ->build();
+
+$query = (new ExchangeRateQueryBuilder('EUR/USD'))
     ->addOption('cache_ttl', 60)
     ->build();
 ```
 
-###### cache
+### HTTP request caching
 
-Disable/Enable caching. Default: `true`
+Some services return all rates for a given base currency in a single response. If you fetch several pairs sharing the same base, caching the underlying HTTP response avoids a second round trip. Decorate your HTTP client with the PHP HTTP cache plugin and pass it to the service constructor:
 
-```php
-// Disable caching for this query
-$query = (new ExchangeRateQueryBuilder('JPY/GBP'))
-    ->addOption('cache', false)
-    ->build();
+```bash
+composer require php-http/cache-plugin cache/array-adapter
 ```
 
-###### cache_key_prefix
-
-Set the cache key prefix. Default: empty string
-
-There is a limitation of 64 characters for the key length in PSR-6, because of this, key prefix must not exceed 24 characters, as sha1() hash takes 40 symbols.
-
-PSR-6 do not allows characters `{}()/\@:` in key, these characters are replaced with `-`
-
 ```php
-// Override cache key prefix for this query
-$query = (new ExchangeRateQueryBuilder('JPY/GBP'))
-    ->addOption('cache_key_prefix', 'currencies-special-')
-    ->build();
-```    
-
-#### Requests Caching
-
-By default, `Exchanger` queries the service for each rate you request, but some services like the `EuropeanCentralBank`
-return the same response no matter the requested currency pair. It means performances can be improved when using these services
-and when quoting multiple pairs during the same request.
-
-Install the PHP HTTP Cache plugin and the PHP Cache Array adapter `composer require php-http/cache-plugin cache/array-adapter`.
-
-Modify the way you create your HTTP Client by decorating it with a `PluginClient` using the `Array` cache:
-
-```php
-use Http\Client\Common\PluginClient;
-use Http\Client\Common\Plugin\CachePlugin;
-use Http\Message\StreamFactory\GuzzleStreamFactory;
-use Http\Adapter\Guzzle6\Client as GuzzleClient;
 use Cache\Adapter\PHPArray\ArrayCachePool;
-use Exchanger\Service\EuropeanCentralBank;
-use Exchanger\ExchangeRateQueryBuilder;
 use Exchanger\Exchanger;
+use Exchanger\ExchangeRateQueryBuilder;
+use Exchanger\Service\EuropeanCentralBank;
+use Http\Adapter\Guzzle7\Client as GuzzleClient;
+use Http\Client\Common\Plugin\CachePlugin;
+use Http\Client\Common\PluginClient;
+use Http\Message\StreamFactory\GuzzleStreamFactory;
 
-$pool = new ArrayCachePool();
+$pool          = new ArrayCachePool();
 $streamFactory = new GuzzleStreamFactory();
-$cachePlugin = new CachePlugin($pool, $streamFactory);
-$httpAdapter = new PluginClient(new GuzzleClient(), [$cachePlugin]);
+$cachePlugin   = new CachePlugin($pool, $streamFactory);
+$httpClient    = new PluginClient(new GuzzleClient(), [$cachePlugin]);
 
-$service = new EuropeanCentralBank($httpAdapter);
-
+$service   = new EuropeanCentralBank($httpClient);
 $exchanger = new Exchanger($service);
 
-$query = (new ExchangeRateQueryBuilder('EUR/USD'))->build();
+$exchanger->getExchangeRate(
+    (new ExchangeRateQueryBuilder('EUR/USD'))->build()
+); // performs an HTTP request
 
-// An http request will be sent
-$rate = $exchanger->getExchangeRate((new ExchangeRateQueryBuilder('EUR/USD'))->build());
-
-// A new request won't be sent
-$rate = $exchanger->getExchangeRate((new ExchangeRateQueryBuilder('EUR/GBP'))->build());
+$exchanger->getExchangeRate(
+    (new ExchangeRateQueryBuilder('EUR/GBP'))->build()
+); // hits the HTTP cache
 ```
 
-### Creating a Service
+## 🔑 Provider configuration
 
-If your service must send http requests to retrieve rates, your class must extend the `HttpService` class, otherwise you can extend the more generic `Service` class.
+Public services need no configuration; instantiate them directly:
 
-#### Standard service
+```php
+use Exchanger\Service\EuropeanCentralBank;
+use Exchanger\Service\NationalBankOfRomania;
 
-In the following example, we are creating a `Constant` service that returns a configurable constant rate value.
+$service = new EuropeanCentralBank();
+$service = new NationalBankOfRomania();
+```
+
+Commercial services take an HTTP client, a request factory (both can be `null`), and an options array. The option key varies by service:
+
+| Service class                                  | Required option | Optional flags        |
+| ---------------------------------------------- | --------------- | --------------------- |
+| `Exchanger\Service\AbstractApi`                | `api_key`       |                       |
+| `Exchanger\Service\ApiLayer\CurrencyData`      | `api_key`       |                       |
+| `Exchanger\Service\ApiLayer\ExchangeRatesData` | `api_key`       |                       |
+| `Exchanger\Service\ApiLayer\Fixer`             | `api_key`       |                       |
+| `Exchanger\Service\CoinLayer`                  | `access_key`    | `paid` (bool)         |
+| `Exchanger\Service\CurrencyConverter`          | `access_key`    | `enterprise` (bool)   |
+| `Exchanger\Service\CurrencyDataFeed`           | `api_key`       |                       |
+| `Exchanger\Service\CurrencyLayer`              | `access_key`    | `enterprise` (bool)   |
+| `Exchanger\Service\ExchangeRatesApi`           | `access_key`    |                       |
+| `Exchanger\Service\FastForex`                  | `api_key`       |                       |
+| `Exchanger\Service\Fixer`                      | `access_key`    |                       |
+| `Exchanger\Service\FixerApiLayer`              | `api_key`       |                       |
+| `Exchanger\Service\Forge`                      | `api_key`       |                       |
+| `Exchanger\Service\OpenExchangeRates`          | `app_id`        | `enterprise` (bool)   |
+| `Exchanger\Service\XchangeApi`                 | `api-key`       | (note the hyphen)     |
+| `Exchanger\Service\Xignite`                    | `token`         |                       |
+
+Example:
+
+```php
+use Exchanger\Service\ApiLayer\Fixer;
+use Exchanger\Service\OpenExchangeRates;
+use Exchanger\Service\Xignite;
+
+$fixer   = new Fixer(null, null, ['api_key' => 'YOUR_KEY']);
+$oer     = new OpenExchangeRates(null, null, ['app_id' => 'YOUR_APP_ID', 'enterprise' => false]);
+$xignite = new Xignite(null, null, ['token' => 'YOUR_TOKEN']);
+```
+
+The `Exchanger\Service\PhpArray` service (registry identifier `array`) is a special case used in tests and fixtures. It accepts a structure of latest and historical rates:
+
+```php
+use Exchanger\Service\PhpArray;
+
+$service = new PhpArray(
+    ['EUR/USD' => 1.1, 'EUR/GBP' => 1.5],          // latest rates
+    ['2017-01-01' => ['EUR/USD' => 1.5]]           // historical rates
+);
+```
+
+The full provider list with capabilities (base currency, quote currency, historical support) is in the [README's Providers table](../README.md#-providers).
+
+## 🧩 Creating a custom service
+
+If your service makes HTTP requests, extend `Exchanger\Service\HttpService`; otherwise extend the simpler `Exchanger\Service\Service`.
+
+### Standard service
+
+The example below creates a `Constant` service that returns a fixed rate value:
 
 ```php
 use Exchanger\Contract\ExchangeRateQuery;
 use Exchanger\Contract\ExchangeRate;
+use Exchanger\Exchanger;
+use Exchanger\ExchangeRateQueryBuilder;
 use Exchanger\Service\HttpService;
 
 class ConstantService extends HttpService
 {
-    /**
-     * Gets the exchange rate.
-     *
-     * @param ExchangeRateQuery $exchangeQuery
-     *
-     * @return ExchangeRate
-     */
     public function getExchangeRate(ExchangeRateQuery $exchangeQuery): ExchangeRate
     {
-        // If you want to make a request you can use
-        // $content = $this->request('http://example.com');
+        // To call an HTTP endpoint:
+        // $content = $this->request('https://example.com');
 
         return $this->createInstantRate($exchangeQuery->getCurrencyPair(), $this->options['value']);
     }
 
-    /**
-     * Processes the service options.
-     *
-     * @param array &$options
-     *
-     * @return void
-     */
     public function processOptions(array &$options): void
     {
         if (!isset($options['value'])) {
@@ -308,142 +339,78 @@ class ConstantService extends HttpService
         }
     }
 
-    /**
-     * Tells if the service supports the exchange rate query.
-     *
-     * @param ExchangeRateQuery $exchangeQuery
-     *
-     * @return bool
-     */
     public function supportQuery(ExchangeRateQuery $exchangeQuery): bool
     {
-        // For example, our service only supports EUR as base currency
+        // Example: only support EUR-base pairs.
         return 'EUR' === $exchangeQuery->getCurrencyPair()->getBaseCurrency();
     }
 
-    /**
-     * Gets the name of the exchange rate service.
-     *
-     * @return string
-     */
     public function getName(): string
     {
         return 'constant';
     }
 }
 
-$service = new ConstantService(null, null, ['value' => 10]);
+$service   = new ConstantService(null, null, ['value' => 10]);
 $exchanger = new Exchanger($service);
 
 $query = (new ExchangeRateQueryBuilder('EUR/USD'))->build();
-
-// 10
-$rate = $exchanger->getExchangeRate($query)->getValue();
+echo $exchanger->getExchangeRate($query)->getValue(); // 10
 ```
 
-#### Historical service
+### Historical service
 
-If your service supports retrieving historical rates, you need to use the `SupportsHistoricalQueries` trait.
-
-You will need to rename the `getExchangeRate` method to `getLatestExchangeRate` and switch its visibility to protected, and implement a new `getHistoricalExchangeRate` method:
+To support historical rates, use the `SupportsHistoricalQueries` trait. Rename `getExchangeRate` to `getLatestExchangeRate` (now `protected`) and implement `getHistoricalExchangeRate`:
 
 ```php
+use Exchanger\Contract\ExchangeRateQuery;
+use Exchanger\Contract\ExchangeRate;
+use Exchanger\HistoricalExchangeRateQuery;
+use Exchanger\Service\HttpService;
 use Exchanger\Service\SupportsHistoricalQueries;
 
 class ConstantService extends HttpService
 {
     use SupportsHistoricalQueries;
-    
-    /**
-     * Gets the exchange rate.
-     *
-     * @param ExchangeRateQuery $exchangeQuery
-     *
-     * @return ExchangeRate
-     */
+
     protected function getLatestExchangeRate(ExchangeRateQuery $exchangeQuery): ExchangeRate
     {
         return $this->createInstantRate($exchangeQuery->getCurrencyPair(), $this->options['value']);
     }
 
-    /**
-     * Gets an historical rate.
-     *
-     * @param HistoricalExchangeRateQuery $exchangeQuery
-     *
-     * @return ExchangeRate
-     */
     protected function getHistoricalExchangeRate(HistoricalExchangeRateQuery $exchangeQuery): ExchangeRate
     {
         return $this->createInstantRate($exchangeQuery->getCurrencyPair(), $this->options['value']);
     }
-}    
+}
 ```
 
-### Supported Services
+## ❓ FAQ
 
-Here is the complete list of supported services and their possible configurations:
+#### What happens when every service in the chain fails?
 
-```php
-use Exchanger\Service\Chain;
-use Exchanger\Service\Fixer;
-use Exchanger\Service\CurrencyLayer;
-use Exchanger\Service\CentralBankOfCzechRepublic;
-use Exchanger\Service\CentralBankOfRepublicTurkey;
-use Exchanger\Service\CurrencyDataFeed;
-use Exchanger\Service\EuropeanCentralBank;
-use Exchanger\Service\ExchangeRatesApi;
-use Exchanger\Service\NationalBankOfRomania;
-use Exchanger\Service\OpenExchangeRates;
-use Exchanger\Service\PhpArray;
-use Exchanger\Service\Forge;
-use Exchanger\Service\WebserviceX;
-use Exchanger\Service\Xignite;
-use Exchanger\Service\RussianCentralBank;
-use Exchanger\Service\Cryptonator;
-use Exchanger\Service\CoinLayer;
-use Exchanger\Service\XchangeApi;
-use Exchanger\Service\AbstractApi;
-use Exchanger\Service\ExchangerateHost;
-use Exchanger\Service\ApiLayer\CurrencyData;
-use Exchanger\Service\ApiLayer\ExchangeRatesData;
-use Exchanger\Service\ApiLayer\Fixer;
+The `Chain` throws an `Exchanger\Exception\ChainException`. Calling `$exception->getExceptions()` on it returns the list of exceptions collected from each service in the chain.
 
-$service = new Chain([
-    new Fixer($client, null, ['api_key' => 'Get your key here: https://fixer.io']),
-    new CurrencyData($client, null, ['api_key' => 'Get your key here: https://currencylayer.com']),
-    new ExchangeRatesData($client, null, ['api_key' => 'Get your key here: https://exchangeratesapi.io']),
-    new AbstractApi($client, null, ['api_key' => 'Get your key here: https://app.abstractapi.com/users/signup']),
-    new CoinLayer($client, null, ['access_key' => 'access_key', 'paid' => false]),
-    new Exchanger\Service\Fixer($client, null, ['access_key' => 'YOUR_KEY']),
-    new CurrencyLayer($client, null, ['access_key' => 'access_key', 'enterprise' => false]),
-    new ExchangeRatesApi($client, null, ['access_key' => 'access_key', 'enterprise' => false]),
-    new EuropeanCentralBank(),
-    new NationalBankOfRomania(),
-    new CentralBankOfRepublicTurkey(),
-    new CentralBankOfCzechRepublic(),
-    new RussianCentralBank(),
-    new Forge($client, null, ['api_key' => 'api_key']),
-    new WebserviceX(),
-    new Cryptonator(),
-    new CurrencyDataFeed($client, null, ['api_key' => 'api_key']),
-    new OpenExchangeRates($client, null, ['app_id' => 'app_id', 'enterprise' => false]),
-    new Xignite($client, null, ['token' => 'token']),
-    new ExchangerateHost(),
-    new PhpArray(
-        [
-            'EUR/USD' => 1.1,
-            'EUR/GBP' => 1.5
-        ],
-        [
-            '2017-01-01' => [
-                'EUR/USD' => 1.5
-            ],
-            '2017-01-03' => [
-                'EUR/GBP' => 1.3
-            ],
-        ]
-    ),
-    new XchangeApi($client, null, ['api-key' => 'YOUR_KEY']),
-]);
-```
+#### Can I use Exchanger without an API key?
+
+Yes. The European Central Bank, the national banks, `Cryptonator`, `ExchangerateHost`, and `WebserviceX` do not require an API key. See the [Providers table](../README.md#-providers) for the full list.
+
+#### How does Exchanger relate to Swap?
+
+Swap is the high-level, easy-to-use API. Exchanger is the lower-level provider layer Swap is built on. Reach for Exchanger directly only when you need finer control over chain composition, caching, or HTTP plumbing. See the README's [Which package should I use?](../README.md#-which-package-should-i-use) section.
+
+#### How do I cache rates?
+
+Pass any PSR-16 cache as the second constructor argument: `new Exchanger($service, $cache)`. See [PSR-16 SimpleCache (minimal setup)](#psr-16-simplecache-minimal-setup).
+
+#### How do I disable cache for a single query?
+
+Add `->addOption('cache', false)` to the query builder.
+
+#### How do I add my own service?
+
+Implement `Exchanger\Contract\ExchangeRateService` (or extend `HttpService` / `Service`), then pass an instance to `Exchanger` directly or wrap it in a `Chain` with other services. See [Creating a custom service](#-creating-a-custom-service).
+
+#### Where is the full provider list with capabilities?
+
+In the [README's Providers table](../README.md#-providers). It lists every supported service with its base currency, quote currency, and historical support.


### PR DESCRIPTION
## What changed

### README

- Rewrote the README around a clearer value proposition: Exchanger is the exchange rate provider layer, the lower-level alternative to Swap, used when you need finer control than the Swap builder exposes.
- New orientation sections (*What is Exchanger?*, *When should you use Exchanger?*, *Why Exchanger over Swap?*, *Common use cases*, *Which package should I use?*), aligned with the Swap README.
- Replaced the APILayer-anchored intro with a neutral default (`european_central_bank`, free, no API key) so the Quickstart works end-to-end without external accounts.
- Reorganized the Providers table into **Public providers (no API key)** and **Commercial providers (require an API key)** groups, alphabetical within each. Added an **Identifier** column with the string registered in ``Exchanger\Service\Registry``. All 30 entries now match the registry; the `Ukranie` typo is fixed.
- Added a cross-link block to Swap, Laravel Swap, and Symfony Swap.
- Added a neutral Sponsorship section near the bottom.
- Added light section emojis for visual scanning.

### `doc/readme.md`

- Dropped the legacy `## Sponsors` block at the top and the *'we recommend the services that support our project'* line in `## Configuration`. No commercial provider is preferred.
- Added the same orientation sections at the top so the doc stands on its own for a discovery-stage reader and aligns vocabulary with the README (*exchange rate provider*, *fallback chain*, *currency conversion*).
- Modernized the Installation section (PSR-18 first via `symfony/http-client`, Guzzle 7 alternative noted; the HTTPlug-first framing is removed).
- Added an explicit *How the chain works* paragraph (skip on unsupported pair, retry on thrown exception, ``ChainException`` after all collected exceptions).
- Compacted *Per-query options* from three sub-headings (`cache_ttl`, `cache`, `cache_key_prefix`) into a single options table plus example block. Same information, denser.
- Updated the HTTP request caching example to use Guzzle 7 instead of the EOL `guzzle6-adapter`.
- Replaced the legacy `## Supported Services` code dump with a focused *Provider configuration* table mapping each commercial service class to its required option (`api_key`, `access_key`, `app_id`, `token`, `api-key`) and optional flags (`enterprise`, `paid`). Public services and the `PhpArray` fixture are documented separately.
- Added a short FAQ (what happens when every service in the chain fails, can I use Exchanger without an API key, how does Exchanger relate to Swap, how do I cache rates, how do I disable cache for a single query, how do I add my own service, where is the full provider list).
- Added the same light section emojis as the README.

### `composer.json`

- Updated description and Packagist keywords for discoverability.

## Why

- Clearer value proposition on the first screen, with explicit positioning against Swap (most apps should use Swap; reach for Exchanger when finer control is needed).
- Quickstart that works end-to-end without an external account.
- Searchable terms (currency conversion, exchange rate API, forex, fallback) present in headings, the opening paragraph, and the Packagist metadata.
- Short factual sections that are easy for both developers and LLMs to reference.
- The doc no longer duplicates the README's Providers table; it focuses on the parts the README cannot cover (per-service constructor option keys, chain semantics, custom service, FAQ).

## What did NOT change

- No runtime code changes. Public API of ``Exchanger\Exchanger``, ``Exchanger\Service\Chain``, and the ``ExchangeRateService`` interface is unchanged.
- No changes to `src/`, `tests/`, CI, Psalm config, or php-cs-fixer config.
- The CHANGELOG was not touched (this is doc work, not a release).