### PR TITLE
Update the fastFOREX.io integration, tests and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Exchanger ships 30 exchange rate provider implementations. Each is registered in
 | currencylayer (direct)           | `currency_layer`                 | USD (free), * (paid)  | *     | Yes        |
 | Exchange Rates Data (APILayer)   | `apilayer_exchange_rates_data`   | USD (free), * (paid)  | *     | Yes        |
 | exchangeratesapi (direct)        | `exchange_rates_api`             | USD (free), * (paid)  | *     | Yes        |
-| fastFOREX.io                     | `fastforex`                      | USD (free), * (paid)  | *     | No         |
+| fastFOREX.io                     | `fastforex`                      | *                     | *     | Yes        |
 | Fixer (APILayer)                 | `apilayer_fixer`                 | EUR (free), * (paid)  | *     | Yes        |
 | Fixer (direct)                   | `fixer`                          | EUR (free), * (paid)  | *     | Yes        |
 | 1Forge                           | `forge`                          | *                     | *     | No         |

--- a/src/Service/FastForex.php
+++ b/src/Service/FastForex.php
@@ -14,25 +14,37 @@ declare(strict_types=1);
 namespace Exchanger\Service;
 
 use Exchanger\Contract\ExchangeRateQuery;
+use Exchanger\Contract\HistoricalExchangeRateQuery;
+use Exchanger\CurrencyPair;
 use Exchanger\Exception\UnsupportedCurrencyPairException;
+use Exchanger\ExchangeRate;
 use Exchanger\StringUtil;
 use Exchanger\Contract\ExchangeRate as ExchangeRateContract;
 
 /**
  * fastFOREX.io Service.
  *
+ * @see https://www.fastforex.io
+ *
  * @author Tom <tom@whamsoftware.com>
  */
 final class FastForex extends HttpService
 {
-    const FETCH_ONE_URL = 'https://api.fastforex.io/fetch-one?from=%s&to=%s&api_key=%s';
+    use SupportsHistoricalQueries;
+
+    const API_KEY_OPTION = 'api_key';
+    const API_KEY_HEADER = 'X-Api-Key';
+
+    const FETCH_ONE_URL = 'https://api.fastforex.io/fetch-one?from=%s&to=%s';
+
+    const HISTORICAL_URL = 'https://api.fastforex.io/historical?date=%s&from=%s&to=%s';
 
     /**
      * {@inheritdoc}
      */
     public function processOptions(array &$options): void
     {
-        if (!isset($options['api_key'])) {
+        if (!isset($options[self::API_KEY_OPTION])) {
             throw new \InvalidArgumentException('The "api_key" option must be provided.');
         }
     }
@@ -42,36 +54,85 @@ final class FastForex extends HttpService
      */
     public function supportQuery(ExchangeRateQuery $exchangeQuery): bool
     {
-        return !$exchangeQuery instanceof \Exchanger\HistoricalExchangeRateQuery;
+        return true;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function getExchangeRate(ExchangeRateQuery $exchangeRateQuery): ExchangeRateContract
+    public function getLatestExchangeRate(ExchangeRateQuery $exchangeQuery): ExchangeRateContract
     {
-        $currencyPair = $exchangeRateQuery->getCurrencyPair();
-        $baseCurrency = $currencyPair->getBaseCurrency();
-        $quoteCurrency = $currencyPair->getQuoteCurrency();
-        $url = sprintf(self::FETCH_ONE_URL, $baseCurrency, $quoteCurrency, $this->options['api_key']);
+        $currencyPair = $exchangeQuery->getCurrencyPair();
+        $response = $this->getResponse(
+            sprintf(
+                self::FETCH_ONE_URL,
+                $currencyPair->getBaseCurrency(),
+                $currencyPair->getQuoteCurrency()
+            ),
+            [
+                self::API_KEY_HEADER => $this->options[self::API_KEY_OPTION],
+            ]
+        );
 
-        $content = $this->request($url);
-        $result = StringUtil::jsonToArray($content);
+        return $this->processResponse($response, $currencyPair, 'result');
+    }
 
-        if (!isset($result['error'])) {
-            try {
-                $date = new \DateTime($result['updated']);
-            } catch (\Throwable $thrown) {
-                $date = new \DateTime();
-            }
-            if (isset($result['base']) && $result['base'] == $baseCurrency) {
-                if (isset($result['result'][$quoteCurrency])) {
-                    return $this->createRate($currencyPair, (float) ($result['result'][$quoteCurrency]), $date);
-                }
+    /**
+     * {@inheritdoc}
+     */
+    protected function getHistoricalExchangeRate(HistoricalExchangeRateQuery $exchangeQuery): ExchangeRateContract
+    {
+        $currencyPair = $exchangeQuery->getCurrencyPair();
+        $response = $this->getResponse(
+            sprintf(
+                self::HISTORICAL_URL,
+                $exchangeQuery->getDate()->format('Y-m-d'),
+                $currencyPair->getBaseCurrency(),
+                $currencyPair->getQuoteCurrency()
+            ),
+            [
+                self::API_KEY_HEADER => $this->options[self::API_KEY_OPTION],
+            ]
+        );
+
+        return $this->processResponse($response, $currencyPair, 'results');
+    }
+
+    protected function processResponse(
+        \Psr\Http\Message\ResponseInterface $response,
+        CurrencyPair $currencyPair,
+        string $resultKey
+    ): ExchangeRate {
+        try {
+            $result = StringUtil::jsonToArray(
+                $response->getBody()->__toString()
+            );
+        } catch (\Throwable $thrown) {
+            $result = ['error' => 'Failed to parse response'];
+        }
+
+        if ($response->getStatusCode() !== 200 || isset($result['error'])) {
+            throw new \Exchanger\Exception\Exception(
+                empty($result['error'])
+                    ? sprintf('Failed with HTTP response code %d', $response->getStatusCode())
+                    : $result['error']
+            );
+        }
+
+        try {
+            $date = new \DateTime($result['updated'] ?? ($result['date'] ?? 'now'));
+        } catch (\Throwable $thrown) {
+            $date = new \DateTime();
+        }
+
+        if (isset($result['base']) && $result['base'] == $currencyPair->getBaseCurrency()) {
+            $quoteCurrency = $currencyPair->getQuoteCurrency();
+            if (isset($result[$resultKey][$quoteCurrency])) {
+                return $this->createRate($currencyPair, (float) ($result[$resultKey][$quoteCurrency]), $date);
             }
         }
 
-        throw new UnsupportedCurrencyPairException($currencyPair, $this);
+        throw new \Exchanger\Exception\Exception('Unknown error');
     }
 
     /**

--- a/tests/Tests/Service/FastForexTest.php
+++ b/tests/Tests/Service/FastForexTest.php
@@ -23,19 +23,19 @@ use PHPUnit\Framework\Attributes\Test;
 class FastForexTest extends ServiceTestCase
 {
     #[Test]
-    public function it_does_not_support_all_queries()
+    public function it_supports_all_queries()
     {
         $service = new FastForex($this->createMock('Http\Client\HttpClient'), null, ['api_key' => 'secret']);
 
         $this->assertTrue($service->supportQuery(new ExchangeRateQuery(CurrencyPair::createFromString('EUR/USD'))));
-        $this->assertFalse($service->supportQuery(new HistoricalExchangeRateQuery(CurrencyPair::createFromString('EUR/USD'), new \DateTime())));
+        $this->assertTrue($service->supportQuery(new HistoricalExchangeRateQuery(CurrencyPair::createFromString('EUR/USD'), new \DateTime())));
     }
 
     #[Test]
     public function it_throws_an_exception_when_rate_not_supported()
     {
         $this->expectException(Exception::class);
-        $url = 'https://api.fastforex.io/fetch-one?from=EUR&to=ZZZ&api_key=secret';
+        $url = 'https://api.fastforex.io/fetch-one?from=EUR&to=ZZZ';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/FastForex/error-unsupported.json');
         $service = new FastForex($this->getHttpAdapterMock($url, $content), null, ['api_key' => 'secret']);
 
@@ -46,7 +46,7 @@ class FastForexTest extends ServiceTestCase
     public function it_fetches_a_rate_when_response_symbol_matches()
     {
         $pair = CurrencyPair::createFromString('USD/EUR');
-        $url = 'https://api.fastforex.io/fetch-one?from=USD&to=EUR&api_key=secret';
+        $url = 'https://api.fastforex.io/fetch-one?from=USD&to=EUR';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/FastForex/one-usd-eur.json');
         $service = new FastForex($this->getHttpAdapterMock($url, $content), null, ['api_key' => 'secret']);
 
@@ -61,9 +61,19 @@ class FastForexTest extends ServiceTestCase
     public function it_throws_an_exception_when_response_symbol_does_not_match()
     {
         $this->expectException(Exception::class);
-        $url = 'https://api.fastforex.io/fetch-one?from=USD&to=AED&api_key=secret';
+        $url = 'https://api.fastforex.io/fetch-one?from=USD&to=AED';
         $content = file_get_contents(__DIR__.'/../../Fixtures/Service/FastForex/one-usd-eur.json');
         $service = new FastForex($this->getHttpAdapterMock($url, $content), null, ['api_key' => 'secret']);
+
+        $service->getExchangeRate(new ExchangeRateQuery(CurrencyPair::createFromString('USD/AED')));
+    }
+
+    #[Test]
+    public function it_throws_an_exception_when_response_status_error()
+    {
+        $this->expectException(Exception::class);
+        $url = 'https://api.fastforex.io/fetch-one?from=USD&to=AED';
+        $service = new FastForex($this->getHttpAdapterMock($url, '', 401), null, ['api_key' => 'secret']);
 
         $service->getExchangeRate(new ExchangeRateQuery(CurrencyPair::createFromString('USD/AED')));
     }

--- a/tests/Tests/Service/ServiceTestCase.php
+++ b/tests/Tests/Service/ServiceTestCase.php
@@ -21,10 +21,11 @@ abstract class ServiceTestCase extends TestCase
      * Create a mocked Response.
      *
      * @param string $content The body content
+     * @param int $statusCode The status code
      *
      * @return \Psr\Http\Message\ResponseInterface
      */
-    private function getResponse($content)
+    private function getResponse($content, $statusCode = 200)
     {
         $body = $this->createMock('Psr\Http\Message\StreamInterface');
         $body
@@ -38,6 +39,10 @@ abstract class ServiceTestCase extends TestCase
             ->method('getBody')
             ->willReturn($body);
 
+        $response
+            ->method('getStatusCode')
+            ->willReturn($statusCode);
+
         return $response;
     }
 
@@ -46,12 +51,13 @@ abstract class ServiceTestCase extends TestCase
      *
      * @param string $url     The url
      * @param string $content The body content
+     * @param int $statusCode The status code
      *
      * @return \Http\Client\HttpClient
      */
-    protected function getHttpAdapterMock($url, $content)
+    protected function getHttpAdapterMock($url, $content, $statusCode = 200)
     {
-        $response = $this->getResponse($content);
+        $response = $this->getResponse($content, $statusCode);
 
         $adapter = $this->createMock('Http\Client\HttpClient');
 


### PR DESCRIPTION
### Added
- Support for historical rates via fastFOREX.io

### Changed
- Allow HTTP response status codes to be mocked in test framework
- Use HTTP headers to pass API key for fastFOREX.io (more secure)